### PR TITLE
竖屏版不隐藏 #hd h2

### DIFF
--- a/kk/zdy1.css
+++ b/kk/zdy1.css
@@ -24,7 +24,7 @@
 /*首页主题加宽*/
 
 @media screen and (orientation: portrait) {
-  #switchwidth,#diy-tg,#um p:last-child,#category_grid,.fl_i,p.xg2,#hd h2,#pt,#chart .y,#onlinelist .ptm.pbm.bbda,.frame-title { display: none; }
+  #switchwidth,#diy-tg,#um p:last-child,#category_grid,.fl_i,p.xg2,#pt,#chart .y,#onlinelist .ptm.pbm.bbda,.frame-title { display: none; }
   #toptb { min-width: unset; }
   .wp { width: 100%; }
   #ls_username, #ls_password { width: 90px; }

--- a/kk/zdy2.css
+++ b/kk/zdy2.css
@@ -27,7 +27,7 @@
 /*关置顶那小叉叉*/
 
 @media screen and (orientation: portrait) {
-  #switchwidth,#diy-tg,#hd h2,#um p:last-child,#ct .bm.bml.pbn,#fd_page_top,#thread_types,.tl .num em,.tl .icn,.tl .th,#cgb,#separatorline td:first-child { display: none; }
+  #switchwidth,#diy-tg,#um p:last-child,#ct .bm.bml.pbn,#fd_page_top,#thread_types,.tl .num em,.tl .icn,.tl .th,#cgb,#separatorline td:first-child { display: none; }
   #toptb { min-width: unset; }
   .wp { width: 100%; }
   #ls_username, #ls_password { width: 90px; }

--- a/kk/zdy3.css
+++ b/kk/zdy3.css
@@ -252,7 +252,7 @@ details summary { color:blue; cursor:pointer; }
 
 
 @media screen and (orientation: portrait) {
-  #switchwidth,#diy-tg,#hd h2,#um p:last-child,.pls,#cgb,#fj { display: none; }/*宽屏切换按钮，diy按钮，logo，积分用户组，头像那列，广告（草稿），电梯*/
+  #switchwidth,#diy-tg,#um p:last-child,.pls,#cgb,#fj { display: none; }/*宽屏切换按钮，diy按钮，logo，积分用户组，头像那列，广告（草稿），电梯*/
   #toptb { min-width: unset; }/*顶上横条*/
   .wp { width: 100%; }/*主体*/
   #ls_username, #ls_password { width: 90px; }

--- a/kk/zdy4.css
+++ b/kk/zdy4.css
@@ -7,7 +7,7 @@
 .sltm { width: 100px !important; }/*主题分类选项*/
 
 @media screen and (orientation: portrait) {
-  #switchwidth,#diy-tg,#hd h2,#um p:last-child,.a_f { display: none; }/*宽屏切换按钮，diy按钮，logo，积分用户组，广告（草稿）*/
+  #switchwidth,#diy-tg,#um p:last-child,.a_f { display: none; }/*宽屏切换按钮，diy按钮，logo，积分用户组，广告（草稿）*/
   #toptb { min-width: unset; }/*顶上横条*/
   .wp { width: 100%; }/*主体*/
   #nv li a { padding: 0 5px; }/*导航栏*/


### PR DESCRIPTION
隐藏 #hd h2 会导致搜索结果无法显示标题
（原先可能是为了隐藏 logo，但后来其实已经在模板里隐藏，CSS 里已无需再隐藏）