### PR TITLE
Rename testScopped to testScoped

### DIFF
--- a/tests/class/filter_var_test.php
+++ b/tests/class/filter_var_test.php
@@ -21,7 +21,7 @@ class TestFilterVar
         assertFalse(is_valid("[::1]:8080"));
     }
 
-    function testScopped()
+    function testScoped()
     {
         assertFalse(is_valid("fe80::8902:43d1:fa45:d468/64"));
         assertFalse(is_valid("fe80::8902:43d1:fa45:d468%10"));


### PR DESCRIPTION
## Summary
- rename test function `testScopped` to `testScoped`

## Testing
- `php -r "define('IN_UNITTESTING',1); require 'tests/runtests.php'; runtests_main();"` *(fails: Class "ip" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd6b14748328857200b39b4b04cb