### PR TITLE
Fix parameter variable name in portal block

### DIFF
--- a/source/include/portalcp/portalcp_block.php
+++ b/source/include/portalcp/portalcp_block.php
@@ -950,11 +950,11 @@ function get_push_item($block, $blockstyle, $id, $idtype, $blockclass = '', $scr
 		$obj = block_script($blockclass, $script);
 	}
 	if($obj && is_object($obj)) {
-		$paramter = array($idtype => intval($id));
-		if(isset($block['param']['picrequired'])) {
-			$paramter['picrequired'] = $block['param']['picrequired'];
-		}
-		$return = $obj->getData($blockstyle, $paramter);
+               $parameter = array($idtype => intval($id));
+               if(isset($block['param']['picrequired'])) {
+                       $parameter['picrequired'] = $block['param']['picrequired'];
+               }
+               $return = $obj->getData($blockstyle, $parameter);
 		if($return['data']) {
 			$item = array_shift($return['data']);
 		}


### PR DESCRIPTION
## Summary
- fix `$paramter` typo by renaming to `$parameter`

## Testing
- `php -l source/include/portalcp/portalcp_block.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd653ebc8328973c4bc2cad89324