### PR TITLE
Add script to inspect settings

### DIFF
--- a/tests/check_settings.php
+++ b/tests/check_settings.php
@@ -1,0 +1,11 @@
+<?php
+require __DIR__ . '/../config/config_global.php';
+require_once __DIR__ . '/../source/class/class_core.php';
+
+$discuz = C::app();
+$discuz->init();
+
+print "domain.app type: " . gettype($_G['setting']['domain']['app']) . "\n";
+print_r($_G['setting']['domain']['app']);
+print "\nfooternavs type: " . gettype($_G['setting']['footernavs']) . "\n";
+print_r($_G['setting']['footernavs']);


### PR DESCRIPTION
## Summary
- revert previous changes
- add a simple PHP script that prints the types and values of the `domain.app` and `footernavs` settings

## Testing
- `php -l tests/check_settings.php`
- `php tests/check_settings.php 2>&1 | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684810ff8c648328b9cd7698c76bf803