### PR TITLE
Add debug script for domain and footer settings

### DIFF
--- a/tests/check_settings.php
+++ b/tests/check_settings.php
@@ -1,0 +1,11 @@
+<?php
+require __DIR__ . '/../config/config_global.php';
+require_once __DIR__ . '/../source/class/class_core.php';
+
+$discuz = C::app();
+$discuz->init();
+
+print "domain.app type: " . gettype($_G['setting']['domain']['app']) . "\n";
+print_r($_G['setting']['domain']['app']);
+print "\nfooternavs type: " . gettype($_G['setting']['footernavs']) . "\n";
+print_r($_G['setting']['footernavs']);

--- a/tests/debug_settings.php
+++ b/tests/debug_settings.php
@@ -1,0 +1,58 @@
+<?php
+require __DIR__ . '/../config/config_global.php';
+define("IN_DISCUZ", true);
+require_once __DIR__ . '/../source/function/function_core.php';
+
+$conf = $_config['db'][1];
+$mysqli = new mysqli($conf['dbhost'], $conf['dbuser'], $conf['dbpw'], $conf['dbname']);
+if ($mysqli->connect_errno) {
+    die("DB connect error: {$mysqli->connect_error}\n");
+}
+$tablepre = $conf['tablepre'];
+
+function fetch_setting($mysqli, $tablepre, $key) {
+    $key = $mysqli->real_escape_string($key);
+    $sql = "SELECT svalue FROM {$tablepre}common_setting WHERE skey='$key'";
+    $res = $mysqli->query($sql);
+    if (!$res) {
+        echo "Query error: " . $mysqli->error . "\n";
+        return null;
+    }
+    $row = $res->fetch_assoc();
+    return $row ? $row['svalue'] : null;
+}
+
+$domain_raw = fetch_setting($mysqli, $tablepre, 'domain');
+// fetch footer navigation entries directly from the common_nav table
+function fetch_footernavs($mysqli, $tablepre) {
+    $sql = "SELECT * FROM {$tablepre}common_nav WHERE navtype=1 ORDER BY displayorder";
+    $res = $mysqli->query($sql);
+    if (!$res) {
+        echo "Query error: " . $mysqli->error . "\n";
+        return [];
+    }
+    $rows = [];
+    while ($row = $res->fetch_assoc()) {
+        $rows[] = $row;
+    }
+    return $rows;
+}
+
+$footernavs_rows = fetch_footernavs($mysqli, $tablepre);
+
+echo "domain raw: ";
+var_dump($domain_raw);
+$domain_arr = dunserialize($domain_raw);
+
+echo "domain after dunserialize:\n";
+var_dump($domain_arr);
+
+if (isset($domain_arr['app'])) {
+    echo "domain.app type: " . gettype($domain_arr['app']) . "\n";
+    var_dump($domain_arr['app']);
+}
+
+echo "footernavs from common_nav:\n";
+var_dump($footernavs_rows);
+
+?>


### PR DESCRIPTION
## Summary
- add `tests/debug_settings.php` to read setting values directly from the database
- tweak the script to fetch footer nav entries from `common_nav`

## Testing
- `php -l tests/check_settings.php`
- `php -l tests/debug_settings.php`
- `php tests/debug_settings.php 2>&1 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_684810ff8c648328b9cd7698c76bf803