### PR TITLE
Move thread tags to thread table

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ This repository contains the source code for the kuing.cjhb.site forum and docum
    ```
 3. Copy `config/config_global_default.php` to `config/config_global.php` and configure the database connection.
 4. Import the database schema from the `install` directory. If you need to rerun the Discuz installer, make sure to remove the `data/install.lock` file first so the setup can proceed.
+
+### Migrating thread tags
+If you are upgrading from an older version where tags were stored in the `pre_forum_post` table,
+execute the following SQL statements:
+
+```sql
+ALTER TABLE `pre_forum_thread` ADD COLUMN `tags` varchar(255) NOT NULL DEFAULT '' AFTER `closed`;
+UPDATE `pre_forum_thread` t
+  INNER JOIN `pre_forum_post` p ON t.tid=p.tid AND p.first=1
+  SET t.tags=p.tags;
+ALTER TABLE `pre_forum_post` DROP COLUMN `tags`;
+```
 5. Launch the site locally:
    ```bash
    php -S localhost:8080

--- a/source/class/class_tag.php
+++ b/source/class/class_tag.php
@@ -95,13 +95,13 @@ class tag
 				$results = C::t('common_tagitem')->select($tagidarray);
 				foreach($results as $result) {
 					$result['tagname'] = addslashes($tagnames[$result['tagid']]['tagname']);
-					if($result['idtype'] == 'tid') {
-						$itemid = $result['itemid'];
-						if(!isset($tidarray[$itemid])) {
-							$post = C::t('forum_post')->fetch_threadpost_by_tid_invisible($itemid);
-							$tidarray[$itemid] = $post['tags'];
-						}
-						$tidarray[$itemid] = str_replace("{$result['tagid']},{$result['tagname']}\t", '', $tidarray[$itemid]);
+                                        if($result['idtype'] == 'tid') {
+                                                $itemid = $result['itemid'];
+                                                if(!isset($tidarray[$itemid])) {
+                                                        $thread = C::t('forum_thread')->fetch($itemid);
+                                                        $tidarray[$itemid] = $thread['tags'];
+                                                }
+                                                $tidarray[$itemid] = str_replace("{$result['tagid']},{$result['tagname']}\t", '', $tidarray[$itemid]);
 					} elseif($result['idtype'] == 'blogid') {
 						$itemid = $result['itemid'];
 						if(!isset($blogidarray[$itemid])) {
@@ -129,12 +129,12 @@ class tag
 			C::t('common_tagitem')->merge_by_tagids($newid, $tagidarray);
 			C::t('common_tag')->delete_byids($tagidarray);
 
-			if($tidarray) {
-				foreach($tidarray as $key => $var) {
-					C::t('forum_post')->update_by_tid('tid:'.$key, $key, array('tags' => $var), false, false, 1);
-					C::t('forum_post')->concat_threadtags_by_tid($key, "$newid,$newtag\t");
-				}
-			}
+                        if($tidarray) {
+                                foreach($tidarray as $key => $var) {
+                                        C::t('forum_thread')->update($key, array('tags' => $var));
+                                        C::t('forum_thread')->concat_tags_by_tid($key, "$newid,$newtag\t");
+                                }
+                        }
 			if($blogidarray) {
 				foreach($blogidarray as $key => $var) {
 					C::t('home_blogfield')->update($key, array('tag' => $var.$newid.','.$newtag.'\t'));
@@ -158,10 +158,10 @@ class tag
 				$result['tagname'] = addslashes($tagnames[$result['tagid']]['tagname']);
 				if($result['idtype'] == 'tid') {
 					$itemid = $result['itemid'];
-					if(!isset($tidarray[$itemid])) {
-						$post = C::t('forum_post')->fetch_threadpost_by_tid_invisible($itemid);
-						$tidarray[$itemid] = $post['tags'];
-					}
+                                        if(!isset($tidarray[$itemid])) {
+                                                $thread = C::t('forum_thread')->fetch($itemid);
+                                                $tidarray[$itemid] = $thread['tags'];
+                                        }
 					$tidarray[$itemid] = str_replace("{$result['tagid']},{$result['tagname']}\t", '', $tidarray[$itemid]);
 				} elseif($result['idtype'] == 'blogid') {
 					$itemid = $result['itemid'];
@@ -174,11 +174,11 @@ class tag
 			}
 		}
 
-		if($tidarray) {
-			foreach($tidarray as $key => $var) {
-				C::t('forum_post')->update_by_tid('tid:'.$key, $key, array('tags' => $var), false, false, 1);
-			}
-		}
+                if($tidarray) {
+                        foreach($tidarray as $key => $var) {
+                                C::t('forum_thread')->update($key, array('tags' => $var));
+                        }
+                }
 		if($blogidarray) {
 			foreach($blogidarray as $key => $var) {
 				C::t('home_blogfield')->update($key, array('tag' => $var));

--- a/source/class/extend/extend_thread_trade.php
+++ b/source/class/extend/extend_thread_trade.php
@@ -75,10 +75,9 @@ class extend_thread_trade extends extend_thread_base {
 			'bbcodeoff' => 0,
 			'smileyoff' => $this->param['smileyoff'],
 			'parseurloff' => $this->param['parseurloff'],
-			'attachment' => 0,
-			'tags' => $this->param['tagstr'],
-			'status' => (defined('IN_MOBILE') ? 8 : 0)
-		));
+                       'attachment' => 0,
+                       'status' => (defined('IN_MOBILE') ? 8 : 0)
+               ));
 		if(!empty($_GET['tradeaid'])) {
 			convertunusedattach($_GET['tradeaid'], $this->tid, $pid);
 		}

--- a/source/class/model/model_forum_post.php
+++ b/source/class/model/model_forum_post.php
@@ -444,8 +444,9 @@ class model_forum_post extends discuz_model {
 					}
 				}
 			}
-			$class_tag = new tag();
-			$tagstr = $class_tag->update_field($this->param['tags'], $this->thread['tid'], 'tid', $this->thread);
+                        $class_tag = new tag();
+                        $tagstr = $class_tag->update_field($this->param['tags'], $this->thread['tid'], 'tid', $this->thread);
+                        C::t('forum_thread')->update($this->thread['tid'], array('tags' => $tagstr));
 
 		} else {
 			if($this->param['subject'] == '' && $this->param['message'] == '' && $this->thread['special'] != 2) {
@@ -489,8 +490,7 @@ class model_forum_post extends discuz_model {
 			'bbcodeoff' => $this->param['bbcodeoff'],
 			'parseurloff' => $this->param['parseurloff'],
 			'smileyoff' => $this->param['smileyoff'],
-			'subject' => $this->param['subject'],
-			'tags' => $tagstr,
+                        'subject' => $this->param['subject'],
 			'port'=>getglobal('remoteport')
 		);
 		if(empty($_GET['minor'])){
@@ -635,7 +635,8 @@ class model_forum_post extends discuz_model {
 			//After deleting 1# we need to set the next post as first post and update the subject and tags
 			if($isfirstpost) {
 				$nextpost = C::t('forum_post')->fetch_visiblepost_by_tid('tid:'.$this->thread['tid'], $this->thread['tid'], 0, 0);// the top post which is not deleted
-				C::t('forum_post')->update_post($this->thread['posttableid'], $nextpost['pid'], array('first' => 1, 'subject' => $this->post['subject'], 'tags' => $this->post['tags']));
+                                C::t('forum_post')->update_post($this->thread['posttableid'], $nextpost['pid'], array('first' => 1, 'subject' => $this->post['subject']));
+                                C::t('forum_thread')->update($this->thread['tid'], array('tags' => $this->post['tags']));
 			}
 		}
 

--- a/source/class/model/model_forum_thread.php
+++ b/source/class/model/model_forum_thread.php
@@ -139,9 +139,10 @@ class model_forum_thread extends discuz_model
 			'moderated' => $this->param['moderated'],
 			'status' => $this->param['tstatus'],
 			'isgroup' => $this->param['isgroup'],
-			'replycredit' => $this->param['replycredit'],
-			'closed' => $this->param['closed'] ? 1 : 0
-		);
+                       'replycredit' => $this->param['replycredit'],
+                       'closed' => $this->param['closed'] ? 1 : 0,
+                       'tags' => $this->param['tagstr']
+               );
 		$this->tid = C::t('forum_thread')->insert($newthread, true);
 		C::t('forum_newthread')->insert(array(
 		    'tid' => $this->tid,
@@ -211,11 +212,10 @@ class model_forum_thread extends discuz_model
 			'bbcodeoff' => $this->param['bbcodeoff'],
 			'smileyoff' => $this->param['smileyoff'],
 			'parseurloff' => $this->param['parseurloff'],
-			'attachment' => '0',
-			'tags' => $this->param['tagstr'],
-			'replycredit' => 0,
-			'status' => $this->param['pstatus']
-		));
+                       'attachment' => '0',
+                       'replycredit' => 0,
+                       'status' => $this->param['pstatus']
+               ));
 
 		$statarr = array(0 => 'thread', 1 => 'poll', 2 => 'trade', 3 => 'reward', 4 => 'activity', 5 => 'debate', 127 => 'thread');
 		include_once libfile('function/stat');

--- a/source/class/table/table_forum_post.php
+++ b/source/class/table/table_forum_post.php
@@ -150,10 +150,17 @@ class table_forum_post extends discuz_table
 				array(self::get_tablename($tableid), $tid));
 	}
 
-	public function fetch_threadpost_by_tid_invisible($tid, $invisible = null) {
-		return DB::fetch_first('SELECT * FROM %t WHERE tid=%d AND first=1'.($invisible !== null ? ' AND '.DB::field('invisible', $invisible) : ''),
-				array(self::get_tablename('tid:'.$tid), $tid));
-	}
+        public function fetch_threadpost_by_tid_invisible($tid, $invisible = null) {
+                $post = DB::fetch_first('SELECT * FROM %t WHERE tid=%d AND first=1'.($invisible !== null ? ' AND '.DB::field('invisible', $invisible) : ''),
+                                array(self::get_tablename('tid:'.$tid), $tid));
+                if($post) {
+                        $thread = C::t('forum_thread')->fetch($tid);
+                        if($thread && isset($thread['tags'])) {
+                                $post['tags'] = $thread['tags'];
+                        }
+                }
+                return $post;
+        }
 
 	public function fetch_pid_by_tid_authorid($tid, $authorid) {
 		return DB::result_first('SELECT pid FROM %t WHERE tid=%d AND authorid=%d LIMIT 1', array(self::get_tablename('tid:'.$tid), $tid, $authorid));
@@ -493,9 +500,13 @@ class table_forum_post extends discuz_table
 		return $return;
 	}
 
-	public function update_by_tid($tableid, $tid, $data, $unbuffered = false, $low_priority = false, $first = null, $invisible = null, $status = null) {
-		$where = array();
-		$where[] = DB::field('tid', $tid);
+        public function update_by_tid($tableid, $tid, $data, $unbuffered = false, $low_priority = false, $first = null, $invisible = null, $status = null) {
+                if(isset($data['tags'])) {
+                        C::t('forum_thread')->update($tid, array('tags' => $data['tags']));
+                        unset($data['tags']);
+                }
+                $where = array();
+                $where[] = DB::field('tid', $tid);
 		if($first !== null) {
 			$where[] = DB::field('first', $first);
 		}
@@ -505,12 +516,15 @@ class table_forum_post extends discuz_table
 		if($status !== null) {
 			$where[] = DB::field('status', $status);
 		}
-		$return = DB::update(self::get_tablename($tableid), $data, implode(' AND ', $where), $unbuffered, $low_priority);
-		if($return && $this->_allowmem) {
-			$this->update_cache(0, $tid, 'tid', $data, array('first' => $first, 'invisible' => $invisible, 'status' => $status));
-		}
-		return $return;
-	}
+                $return = 0;
+                if($data) {
+                        $return = DB::update(self::get_tablename($tableid), $data, implode(' AND ', $where), $unbuffered, $low_priority);
+                        if($return && $this->_allowmem) {
+                                $this->update_cache(0, $tid, 'tid', $data, array('first' => $first, 'invisible' => $invisible, 'status' => $status));
+                        }
+                }
+                return $return;
+        }
 
 	public function update_fid_by_fid($tableid, $fid, $newfid, $unbuffered = false, $low_priority = false) {
 		$where = array();
@@ -614,13 +628,9 @@ class table_forum_post extends discuz_table
 		}
 	}
 
-	public function concat_threadtags_by_tid($tid, $tags) {
-		$return = DB::query('UPDATE %t SET tags=concat(tags, %s) WHERE tid=%d AND first=1', array(self::get_tablename('tid:'.$tid), $tags, $tid));
-		if($return && $this->_allowmem) {
-			$this->update_cache(0, $tid, 'tid', array('tags' => $tags), array('first' => 1), '.');
-		}
-		return $return;
-	}
+        public function concat_threadtags_by_tid($tid, $tags) {
+                return C::t('forum_thread')->concat_tags_by_tid($tid, $tags);
+        }
 
 
 	public function increase_rate_by_pid($tableid, $pid, $rate, $ratetimes) {

--- a/source/class/table/table_forum_thread.php
+++ b/source/class/table/table_forum_thread.php
@@ -960,13 +960,17 @@ class table_forum_thread extends discuz_table
 		return 0;
 	}
 
-	public function insert_thread_copy_by_tid($tids, $origin = 0, $target = 0) {
-		$tids = dintval($tids, true);
-		if($tids) {
-			$wheresql = is_array($tids) && $tids ? 'tid IN(%n)' : 'tid=%d';
-			DB::query("INSERT INTO %t SELECT * FROM %t WHERE $wheresql", array($this->get_table_name($target), $this->get_table_name($origin), $tids));
-		}
-	}
+        public function insert_thread_copy_by_tid($tids, $origin = 0, $target = 0) {
+                $tids = dintval($tids, true);
+                if($tids) {
+                        $wheresql = is_array($tids) && $tids ? 'tid IN(%n)' : 'tid=%d';
+                        DB::query("INSERT INTO %t SELECT * FROM %t WHERE $wheresql", array($this->get_table_name($target), $this->get_table_name($origin), $tids));
+                }
+        }
+
+        public function concat_tags_by_tid($tid, $tags) {
+                return DB::query('UPDATE %t SET tags=concat(tags, %s) WHERE tid=%d', array($this->get_table_name(), $tags, $tid));
+        }
 
 	public function count_by_authorid($authorid, $tableid = 0) {
 		return DB::result_first("SELECT COUNT(*) FROM %t WHERE authorid=%d", array($this->get_table_name($tableid), $authorid));

--- a/source/module/forum/forum_tag.php
+++ b/source/module/forum/forum_tag.php
@@ -110,9 +110,9 @@ if($op == 'search') {
 		}
 	}
 } elseif($op == 'set' && $_GET['formhash'] == FORMHASH && $_G['group']['allowmanagetag']) {
-	$class_tag = new tag();
-	$tagstr = $class_tag->update_field($_GET['tags'], $_G['tid'], 'tid', $_G['thread']);
-	C::t('forum_post')->update_by_tid('tid:'.$_G['tid'], $_G['tid'], array('tags' => $tagstr), false, false, 1);
+        $class_tag = new tag();
+        $tagstr = $class_tag->update_field($_GET['tags'], $_G['tid'], 'tid', $_G['thread']);
+        C::t('forum_thread')->update($_G['tid'], array('tags' => $tagstr));
 }
 
 include_once template("forum/tag");


### PR DESCRIPTION
## Summary
- store thread tags in `pre_forum_thread` instead of first post
- update tag management logic and post/thread models
- provide SQL instructions for migrating existing data

## Testing
- `curl -I 127.0.0.1:8000/index.php`
- `curl -I 127.0.0.1:8000/forum.php?mod=viewthread&tid=9201`
- `curl -I 127.0.0.1:8000/misc.php?mod=tag&id=47`

------
https://chatgpt.com/codex/tasks/task_e_6848b5beb2d88328bcd55b25c1b0e310