### PR TITLE
Fix newline after converting headers in bbcode.js

### DIFF
--- a/static/js/bbcode.js
+++ b/static/js/bbcode.js
@@ -371,26 +371,30 @@ function html2bbcode(str) {
 			'(<t[dh]([^>]*(left|center|right)[^>]*)>)\\\s*([\\\s\\\S]+?)\\\s*(<\/t[dh]>)',
 			'<t[dh]([^>]*(width|colspan|rowspan)[^>]*)>',
 			'<t[dh][^>]*>',
-			'<\/t[dh]>',
-			'<\/tr>',
-			'<\/table>',
-			'<h\\\d[^>]*>',
-			'<\/h\\\d>'
-		], [
-			function($1, $2, $3) {return '[float=' + $2 + ']' + $3 + '[/float]';},
-			function($1, $2) {return tabletag($2);},
-			'[table]\n',
-			function($1, $2, $3) {return '[tr=' + $3 + ']';},
-			'[tr]',
-			function($1, $2, $3, $4, $5, $6) {return $2 + '[align=' + $4 + ']' + $5 + '[/align]' + $6},
-			function($1, $2) {return tdtag($2);},
-			'[td]',
-			'[/td]',
-			'[/tr]\n',
-			'[/table]',
-			'[b]',
-			'[/b]'
-		], str);
+                       '<\/t[dh]>',
+                       '<\/tr>',
+                       '<\/table>',
+                       '<h[23][^>]*>',
+                       '<\/h[23]>',
+                       '<h\\\d[^>]*>',
+                       '<\/h\\\d>'
+               ], [
+                       function($1, $2, $3) {return '[float=' + $2 + ']' + $3 + '[/float]';},
+                       function($1, $2) {return tabletag($2);},
+                       '[table]\n',
+                       function($1, $2, $3) {return '[tr=' + $3 + ']';},
+                       '[tr]',
+                       function($1, $2, $3, $4, $5, $6) {return $2 + '[align=' + $4 + ']' + $5 + '[/align]' + $6},
+                       function($1, $2) {return tdtag($2);},
+                       '[td]',
+                       '[/td]',
+                       '[/tr]\n',
+                       '[/table]',
+                       '[b]',
+                       '[/b]\n',
+                       '[b]',
+                       '[/b]'
+               ], str);
 
 		str = str.replace(/<h([0-9]+)[^>]*>([\s\S]*?)<\/h\1>/ig, function($1, $2, $3) {return "[size=" + (7 - $2) + "]" + $3 + "[/size]\n\n";});
 		str = str.replace(/<hr[^>]*>/ig, "[hr]");


### PR DESCRIPTION
## Summary
- add special case for `<h2>` and `<h3>` when converting HTML to BBCode
- append a newline after closing `[/b]` for those headers

Close #186 

------
https://chatgpt.com/codex/tasks/task_e_6848c1b11c3c8328b5b18d3653a10a38