### PR TITLE
Move thread tags to thread table

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,26 @@ This repository contains the source code for the kuing.cjhb.site forum and docum
    ```
 3. Copy `config/config_global_default.php` to `config/config_global.php` and configure the database connection.
 4. Import the database schema from the `install` directory. If you need to rerun the Discuz installer, make sure to remove the `data/install.lock` file first so the setup can proceed.
-5. Launch the site locally:
+5. *(Optional)* Populate the database with the Monday backup used in tests:
+   ```bash
+   wget -O backup.sql.gz https://kuing.cjhb.site/uc_server/data/backup_monday.sql.gz
+   gzip -d backup.sql.gz
+   sed -i 's/utf8mb4_0900_ai_ci/utf8mb4_general_ci/g' backup.sql
+   mysql -u root ultrax < backup.sql
+   ```
+
+### Migrating thread tags
+If you are upgrading from an older version where tags were stored in the `pre_forum_post` table,
+execute the following SQL statements:
+
+```sql
+ALTER TABLE `pre_forum_thread` ADD COLUMN `tags` varchar(255) NOT NULL DEFAULT '' AFTER `closed`;
+UPDATE `pre_forum_thread` t
+  INNER JOIN `pre_forum_post` p ON t.tid=p.tid AND p.first=1
+  SET t.tags=p.tags;
+ALTER TABLE `pre_forum_post` DROP COLUMN `tags`;
+```
+6. Launch the site locally:
    ```bash
    php -S localhost:8080
    ```

--- a/kk/zdy2.css
+++ b/kk/zdy2.css
@@ -7,6 +7,17 @@
 .tl cite { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 /*主题列表作者、回复数、最后发表调整*/
 
+.thread-tags { margin-top: 5px; clear: both; }
+.thread-tags .tag-item {
+    display: inline-block;
+    background-color: #e1ecf4;
+    color: #39739d;
+    padding: 2px 6px;
+    border-radius: 3px;
+    margin-right: 4px;
+    font-size: 12px;
+}
+
 .tl th a:visited { color: unset; }
 /*访问过的链接不要变浅*/
 

--- a/source/archiver/forum/forumdisplay.php
+++ b/source/archiver/forum/forumdisplay.php
@@ -17,11 +17,18 @@ include loadarchiver('common/header');
 	</ul>
 	<?php endif; ?>
 	<ul type="1" start="1">
-		<?php foreach($_G['forum_threadlist'] as $thread): ?>
-			<?php if($thread['isgroup'] == 0): ?>
-			<li><a href="?tid-<?php echo $thread['tid']; ?>.html"><?php echo $thread['subject']; ?></a> (<?php echo $thread['replies'] . lang('forum/archiver', 'replies'); ?>)
-			<?php endif; ?>
-		<?php endforeach; ?>
+               <?php foreach($_G['forum_threadlist'] as $thread): ?>
+                       <?php if($thread['isgroup'] == 0): ?>
+                        <li><a href="?tid-<?php echo $thread['tid']; ?>.html"><?php echo $thread['subject']; ?></a> (<?php echo $thread['replies'] . lang('forum/archiver', 'replies'); ?>)
+                        <?php if(!empty($thread['taglist'])): ?>
+                                <div>
+                                <?php foreach($thread['taglist'] as $tag): ?>
+                                        <span style="background:#e1ecf4;color:#39739d;padding:2px 6px;border-radius:3px;margin-right:4px;"><?php echo dhtmlspecialchars($tag['tagname']); ?></span>
+                                <?php endforeach; ?>
+                                </div>
+                        <?php endif; ?>
+                        <?php endif; ?>
+                <?php endforeach; ?>
 	</ul>
 	<div class="page">
 		<?php echo arch_multi($_G['forum_threadcount'], $_G['tpp'], $page, "?fid-{$_G['fid']}.html"); ?>

--- a/source/class/class_tag.php
+++ b/source/class/class_tag.php
@@ -95,13 +95,13 @@ class tag
 				$results = C::t('common_tagitem')->select($tagidarray);
 				foreach($results as $result) {
 					$result['tagname'] = addslashes($tagnames[$result['tagid']]['tagname']);
-					if($result['idtype'] == 'tid') {
-						$itemid = $result['itemid'];
-						if(!isset($tidarray[$itemid])) {
-							$post = C::t('forum_post')->fetch_threadpost_by_tid_invisible($itemid);
-							$tidarray[$itemid] = $post['tags'];
-						}
-						$tidarray[$itemid] = str_replace("{$result['tagid']},{$result['tagname']}\t", '', $tidarray[$itemid]);
+                                        if($result['idtype'] == 'tid') {
+                                                $itemid = $result['itemid'];
+                                                if(!isset($tidarray[$itemid])) {
+                                                        $thread = C::t('forum_thread')->fetch($itemid);
+                                                        $tidarray[$itemid] = $thread['tags'];
+                                                }
+                                                $tidarray[$itemid] = str_replace("{$result['tagid']},{$result['tagname']}\t", '', $tidarray[$itemid]);
 					} elseif($result['idtype'] == 'blogid') {
 						$itemid = $result['itemid'];
 						if(!isset($blogidarray[$itemid])) {
@@ -129,12 +129,12 @@ class tag
 			C::t('common_tagitem')->merge_by_tagids($newid, $tagidarray);
 			C::t('common_tag')->delete_byids($tagidarray);
 
-			if($tidarray) {
-				foreach($tidarray as $key => $var) {
-					C::t('forum_post')->update_by_tid('tid:'.$key, $key, array('tags' => $var), false, false, 1);
-					C::t('forum_post')->concat_threadtags_by_tid($key, "$newid,$newtag\t");
-				}
-			}
+                        if($tidarray) {
+                                foreach($tidarray as $key => $var) {
+                                        C::t('forum_thread')->update($key, array('tags' => $var));
+                                        C::t('forum_thread')->concat_tags_by_tid($key, "$newid,$newtag\t");
+                                }
+                        }
 			if($blogidarray) {
 				foreach($blogidarray as $key => $var) {
 					C::t('home_blogfield')->update($key, array('tag' => $var.$newid.','.$newtag.'\t'));
@@ -158,10 +158,10 @@ class tag
 				$result['tagname'] = addslashes($tagnames[$result['tagid']]['tagname']);
 				if($result['idtype'] == 'tid') {
 					$itemid = $result['itemid'];
-					if(!isset($tidarray[$itemid])) {
-						$post = C::t('forum_post')->fetch_threadpost_by_tid_invisible($itemid);
-						$tidarray[$itemid] = $post['tags'];
-					}
+                                        if(!isset($tidarray[$itemid])) {
+                                                $thread = C::t('forum_thread')->fetch($itemid);
+                                                $tidarray[$itemid] = $thread['tags'];
+                                        }
 					$tidarray[$itemid] = str_replace("{$result['tagid']},{$result['tagname']}\t", '', $tidarray[$itemid]);
 				} elseif($result['idtype'] == 'blogid') {
 					$itemid = $result['itemid'];
@@ -174,11 +174,11 @@ class tag
 			}
 		}
 
-		if($tidarray) {
-			foreach($tidarray as $key => $var) {
-				C::t('forum_post')->update_by_tid('tid:'.$key, $key, array('tags' => $var), false, false, 1);
-			}
-		}
+                if($tidarray) {
+                        foreach($tidarray as $key => $var) {
+                                C::t('forum_thread')->update($key, array('tags' => $var));
+                        }
+                }
 		if($blogidarray) {
 			foreach($blogidarray as $key => $var) {
 				C::t('home_blogfield')->update($key, array('tag' => $var));

--- a/source/class/extend/extend_thread_trade.php
+++ b/source/class/extend/extend_thread_trade.php
@@ -75,10 +75,9 @@ class extend_thread_trade extends extend_thread_base {
 			'bbcodeoff' => 0,
 			'smileyoff' => $this->param['smileyoff'],
 			'parseurloff' => $this->param['parseurloff'],
-			'attachment' => 0,
-			'tags' => $this->param['tagstr'],
-			'status' => (defined('IN_MOBILE') ? 8 : 0)
-		));
+                       'attachment' => 0,
+                       'status' => (defined('IN_MOBILE') ? 8 : 0)
+               ));
 		if(!empty($_GET['tradeaid'])) {
 			convertunusedattach($_GET['tradeaid'], $this->tid, $pid);
 		}

--- a/source/class/model/model_forum_post.php
+++ b/source/class/model/model_forum_post.php
@@ -444,8 +444,9 @@ class model_forum_post extends discuz_model {
 					}
 				}
 			}
-			$class_tag = new tag();
-			$tagstr = $class_tag->update_field($this->param['tags'], $this->thread['tid'], 'tid', $this->thread);
+                        $class_tag = new tag();
+                        $tagstr = $class_tag->update_field($this->param['tags'], $this->thread['tid'], 'tid', $this->thread);
+                        C::t('forum_thread')->update($this->thread['tid'], array('tags' => $tagstr));
 
 		} else {
 			if($this->param['subject'] == '' && $this->param['message'] == '' && $this->thread['special'] != 2) {
@@ -489,8 +490,7 @@ class model_forum_post extends discuz_model {
 			'bbcodeoff' => $this->param['bbcodeoff'],
 			'parseurloff' => $this->param['parseurloff'],
 			'smileyoff' => $this->param['smileyoff'],
-			'subject' => $this->param['subject'],
-			'tags' => $tagstr,
+                        'subject' => $this->param['subject'],
 			'port'=>getglobal('remoteport')
 		);
 		if(empty($_GET['minor'])){
@@ -635,7 +635,8 @@ class model_forum_post extends discuz_model {
 			//After deleting 1# we need to set the next post as first post and update the subject and tags
 			if($isfirstpost) {
 				$nextpost = C::t('forum_post')->fetch_visiblepost_by_tid('tid:'.$this->thread['tid'], $this->thread['tid'], 0, 0);// the top post which is not deleted
-				C::t('forum_post')->update_post($this->thread['posttableid'], $nextpost['pid'], array('first' => 1, 'subject' => $this->post['subject'], 'tags' => $this->post['tags']));
+                                C::t('forum_post')->update_post($this->thread['posttableid'], $nextpost['pid'], array('first' => 1, 'subject' => $this->post['subject']));
+                                C::t('forum_thread')->update($this->thread['tid'], array('tags' => $this->post['tags']));
 			}
 		}
 

--- a/source/class/model/model_forum_thread.php
+++ b/source/class/model/model_forum_thread.php
@@ -139,9 +139,10 @@ class model_forum_thread extends discuz_model
 			'moderated' => $this->param['moderated'],
 			'status' => $this->param['tstatus'],
 			'isgroup' => $this->param['isgroup'],
-			'replycredit' => $this->param['replycredit'],
-			'closed' => $this->param['closed'] ? 1 : 0
-		);
+                       'replycredit' => $this->param['replycredit'],
+                       'closed' => $this->param['closed'] ? 1 : 0,
+                       'tags' => $this->param['tagstr']
+               );
 		$this->tid = C::t('forum_thread')->insert($newthread, true);
 		C::t('forum_newthread')->insert(array(
 		    'tid' => $this->tid,
@@ -211,11 +212,10 @@ class model_forum_thread extends discuz_model
 			'bbcodeoff' => $this->param['bbcodeoff'],
 			'smileyoff' => $this->param['smileyoff'],
 			'parseurloff' => $this->param['parseurloff'],
-			'attachment' => '0',
-			'tags' => $this->param['tagstr'],
-			'replycredit' => 0,
-			'status' => $this->param['pstatus']
-		));
+                       'attachment' => '0',
+                       'replycredit' => 0,
+                       'status' => $this->param['pstatus']
+               ));
 
 		$statarr = array(0 => 'thread', 1 => 'poll', 2 => 'trade', 3 => 'reward', 4 => 'activity', 5 => 'debate', 127 => 'thread');
 		include_once libfile('function/stat');

--- a/source/class/table/table_forum_thread.php
+++ b/source/class/table/table_forum_thread.php
@@ -960,13 +960,17 @@ class table_forum_thread extends discuz_table
 		return 0;
 	}
 
-	public function insert_thread_copy_by_tid($tids, $origin = 0, $target = 0) {
-		$tids = dintval($tids, true);
-		if($tids) {
-			$wheresql = is_array($tids) && $tids ? 'tid IN(%n)' : 'tid=%d';
-			DB::query("INSERT INTO %t SELECT * FROM %t WHERE $wheresql", array($this->get_table_name($target), $this->get_table_name($origin), $tids));
-		}
-	}
+        public function insert_thread_copy_by_tid($tids, $origin = 0, $target = 0) {
+                $tids = dintval($tids, true);
+                if($tids) {
+                        $wheresql = is_array($tids) && $tids ? 'tid IN(%n)' : 'tid=%d';
+                        DB::query("INSERT INTO %t SELECT * FROM %t WHERE $wheresql", array($this->get_table_name($target), $this->get_table_name($origin), $tids));
+                }
+        }
+
+        public function concat_tags_by_tid($tid, $tags) {
+                return DB::query('UPDATE %t SET tags=concat(tags, %s) WHERE tid=%d', array($this->get_table_name(), $tags, $tid));
+        }
 
 	public function count_by_authorid($authorid, $tableid = 0) {
 		return DB::result_first("SELECT COUNT(*) FROM %t WHERE authorid=%d", array($this->get_table_name($tableid), $authorid));

--- a/source/module/forum/forum_forumdisplay.php
+++ b/source/module/forum/forum_forumdisplay.php
@@ -824,14 +824,23 @@ foreach($threadlist as $thread) {
 		$verifyuids[$thread['authorid']] = $thread['authorid'];
 	}
 	$authorids[$thread['authorid']] = $thread['authorid'];
-	$thread['mobile'] = base_convert(getstatus($thread['status'], 13).getstatus($thread['status'], 12).getstatus($thread['status'], 11), 2, 10);
-	$thread['rushreply'] = getstatus($thread['status'], 3);
-	if($thread['rushreply']) {
-		$rushtids[$thread['tid']] = $thread['tid'];
-	}
-	$threadids[$threadindex] = $thread['tid'];
-	$_G['forum_threadlist'][$threadindex] = $thread;
-	$threadindex++;
+        $thread['mobile'] = base_convert(getstatus($thread['status'], 13).getstatus($thread['status'], 12).getstatus($thread['status'], 11), 2, 10);
+        $thread['rushreply'] = getstatus($thread['status'], 3);
+        if($thread['rushreply']) {
+                $rushtids[$thread['tid']] = $thread['tid'];
+        }
+        $thread['taglist'] = array();
+        if(!empty($thread['tags'])) {
+                foreach(explode("\t", $thread['tags']) as $var) {
+                        if($var) {
+                                list($tagid, $tagname) = explode(',', $var);
+                                $thread['taglist'][] = array('tagid' => $tagid, 'tagname' => $tagname);
+                        }
+                }
+        }
+        $threadids[$threadindex] = $thread['tid'];
+        $_G['forum_threadlist'][$threadindex] = $thread;
+        $threadindex++;
 
 }
 

--- a/source/module/forum/forum_tag.php
+++ b/source/module/forum/forum_tag.php
@@ -110,9 +110,9 @@ if($op == 'search') {
 		}
 	}
 } elseif($op == 'set' && $_GET['formhash'] == FORMHASH && $_G['group']['allowmanagetag']) {
-	$class_tag = new tag();
-	$tagstr = $class_tag->update_field($_GET['tags'], $_G['tid'], 'tid', $_G['thread']);
-	C::t('forum_post')->update_by_tid('tid:'.$_G['tid'], $_G['tid'], array('tags' => $tagstr), false, false, 1);
+        $class_tag = new tag();
+        $tagstr = $class_tag->update_field($_GET['tags'], $_G['tid'], 'tid', $_G['thread']);
+        C::t('forum_thread')->update($_G['tid'], array('tags' => $tagstr));
 }
 
 include_once template("forum/tag");

--- a/source/module/forum/forum_viewthread.php
+++ b/source/module/forum/forum_viewthread.php
@@ -681,8 +681,8 @@ foreach($postarr as $post) {
 			} else {
 				$summary = str_replace(array("\r", "\n"), '', messagecutstr(strip_tags($post['message']), 200));
 			}
-			$tagarray_all = $posttag_array = array();
-			$tagarray_all = explode("\t", $post['tags']);
+                        $tagarray_all = $posttag_array = array();
+                        $tagarray_all = explode("\t", $_G['forum_thread']['tags']);
 			if($tagarray_all) {
 				foreach($tagarray_all as $var) {
 					if($var) {

--- a/template/default/forum/forumdisplay_list.htm
+++ b/template/default/forum/forumdisplay_list.htm
@@ -159,7 +159,12 @@
 										<!--{if $thread['moved']}-->
 											{lang thread_moved}:<!--{eval $thread['tid']=$thread['closed'];}-->
 										<!--{/if}-->
-										<a href="forum.php?mod=viewthread&tid=$thread[tid]{if $_GET['archiveid']}&archiveid={$_GET['archiveid']}{/if}{if $extra != 'page%3D1'}&extra=$extra{/if}"$thread[highlight]{if $thread['isgroup'] == 1 || $thread['forumstick']} target="_blank"{else} onclick="atarget(this)"{/if} class="s xst">$thread[subject]</a><!-- kk edt -->
+                                                                        <a href="forum.php?mod=viewthread&tid=$thread[tid]{if $_GET['archiveid']}&archiveid={$_GET['archiveid']}{/if}{if $extra != 'page%3D1'}&extra=$extra{/if}"$thread[highlight]{if $thread['isgroup'] == 1 || $thread['forumstick']} target="_blank"{else} onclick="atarget(this)"{/if} class="s xst">$thread[subject]</a><!-- kk edt -->
+                                                                        <!--{if $thread[taglist]}-->
+                                                                        <div class="thread-tags">
+                                                                                <!--{loop $thread[taglist] $tag}--><span class="tag-item"><a href="misc.php?mod=tag&id=$tag[tagid]&name={echo urlencode($tag[tagname])}" target="_blank">$tag[tagname]</a></span><!--{/loop}-->
+                                                                        </div>
+                                                                        <!--{/if}-->
 										<!--{if $_G['setting']['threadhidethreshold'] && $thread['hidden'] >= $_G['setting']['threadhidethreshold']}--><span class="xg1">{lang hidden}</span>&nbsp;<!--{/if}-->
 										<!--{if $thread[icon] >= 0}-->
 											<img src="{STATICURL}image/stamp/{$_G[cache][stamps][$thread[icon]][url]}" alt="{$_G[cache][stamps][$thread[icon]][text]}" class="vm" />


### PR DESCRIPTION
## Summary
- store thread tags in `pre_forum_thread` instead of first post
- update tag management logic and post/thread models
- provide SQL instructions for migrating existing data
- show thread tags in forum list and archiver pages
- add CSS styling for tag badges

## Testing
- `php -l source/module/forum/forum_forumdisplay.php`
- `php -l source/archiver/forum/forumdisplay.php`


------
https://chatgpt.com/codex/tasks/task_e_6848b5beb2d88328bcd55b25c1b0e310