### PR TITLE
Fix related thread ranking order

### DIFF
--- a/source/module/forum/forum_viewthread.php
+++ b/source/module/forum/forum_viewthread.php
@@ -1591,29 +1591,29 @@ function getrelateitem($tagarray, $tid, $relatenum, $relatetime, $relatecache = 
 	} else {
 		$updatecache = 1;
 	}
-	if($updatecache) {
-		$query = C::t('common_tagitem')->select($tagidarray, $tid, $type, 'itemid', 'DESC', $limit, 0, '<>');
-		foreach($query as $result) {
-			if($result['itemid']) {
-				$relatearray[] = $result['itemid'];
-			}
-		}
-		if($relatearray) {
-			$relatebytag = implode(',', $relatearray);
-		}
-		C::t('forum_thread')->update($tid, array('relatebytag'=>TIMESTAMP."\t".$relatebytag));
-	}
+       if($updatecache) {
+               foreach(DB::fetch_all('SELECT itemid, COUNT(*) AS tagnum FROM %t WHERE tagid IN (%n) AND itemid<>%d AND idtype=%s GROUP BY itemid ORDER BY tagnum DESC, itemid DESC LIMIT %d',
+                       array('common_tagitem', $tagidarray, $tid, $type, $limit)) as $result) {
+                       if($result['itemid']) {
+                               $relatearray[] = $result['itemid'];
+                       }
+               }
+               if($relatearray) {
+                       $relatebytag = implode(',', $relatearray);
+               }
+               C::t('forum_thread')->update($tid, array('relatebytag'=>TIMESTAMP."\t".$relatebytag));
+       }
 
 
-	if(!empty($relatearray)) {
-		rsort($relatearray);
-		foreach(C::t('forum_thread')->fetch_all_by_tid($relatearray) as $result) {
-			if($result['displayorder'] >= 0) {
-				$relateitem[] = $result;
-			}
-		}
-	}
-	return $relateitem;
+       if(!empty($relatearray)) {
+               foreach($relatearray as $rtid) {
+                       $result = C::t('forum_thread')->fetch($rtid);
+                       if($result && $result['displayorder'] >= 0) {
+                               $relateitem[] = $result;
+                       }
+               }
+       }
+       return $relateitem;
 }
 
 function rushreply_rule () {


### PR DESCRIPTION
## Summary
- preserve SQL order for related threads when filling cache
- keep misc init script unchanged

## Testing
- `php -l source/module/forum/forum_viewthread.php`
- `php -l source/module/misc/misc_initsys.php`
- `mysql -u root ultrax -e "SELECT itemid, COUNT(*) AS tagnum FROM pre_common_tagitem WHERE tagid IN (21,22,47) AND itemid<>7279 AND idtype='tid' GROUP BY itemid ORDER BY tagnum DESC, itemid DESC LIMIT 10;" | head`
- `curl -I "127.0.0.1/forum.php?mod=viewthread&tid=7279" -H "User-Agent: Mozilla/5.0" -H "Accept: text/html" -H "Accept-Language: en-US" -H "Accept-Encoding: gzip" -H "Sec-Fetch-Mode: navigate"`

------
https://chatgpt.com/codex/tasks/task_e_68494a9c334c83288a1cc35b36e07113