### PR TITLE
Integrate Discuz session with DocPHT

### DIFF
--- a/doc.php
+++ b/doc.php
@@ -1,6 +1,7 @@
 <?php ini_set('display_errors', 1); // IMPORTANT not to use in production
 
 use DocPHT\Core\Session\Session;
+use DocPHT\Core\Helper\DiscuzBridge;
 
 /**
  * This file is part of the DocPHT project.
@@ -72,6 +73,8 @@ $session->preventStealingSession();
 
 require $constants;
 require $configurationFile;
+
+DiscuzBridge::syncSession();
 
 $loader = new Nette\Loaders\RobotLoader;
 $loader->addDirectory(__DIR__ . '/src');

--- a/src/core/Helper/DiscuzBridge.php
+++ b/src/core/Helper/DiscuzBridge.php
@@ -1,0 +1,114 @@
+<?php
+namespace DocPHT\Core\Helper;
+
+use DocPHT\Model\AdminModel;
+
+class DiscuzBridge
+{
+    public static function syncSession()
+    {
+        if (isset($_SESSION['Active'])) {
+            return;
+        }
+        $configPath = __DIR__ . '/../../../config/config_global.php';
+        if (!file_exists($configPath)) {
+            return;
+        }
+        include $configPath;
+        if (!isset($_config['cookie']['cookiepre']) || !isset($_config['security']['authkey'])) {
+            return;
+        }
+        $cookiePre = $_config['cookie']['cookiepre'] .
+            substr(md5($_config['cookie']['cookiepath'] . '|' . $_config['cookie']['cookiedomain']), 0, 4) .
+            '_';
+        $authCookie = $cookiePre . 'auth';
+        $saltCookie = $cookiePre . 'saltkey';
+        if (empty($_COOKIE[$authCookie]) || empty($_COOKIE[$saltCookie])) {
+            return;
+        }
+        $authkey = md5($_config['security']['authkey'] . $_COOKIE[$saltCookie]);
+        $data = self::authcode(urldecode($_COOKIE[$authCookie]), 'DECODE', $authkey);
+        if (empty($data) || strpos($data, "\t") === false) {
+            return;
+        }
+        list($password, $uid) = explode("\t", $data);
+        if (!$uid) {
+            return;
+        }
+        $db = $_config['db'][1];
+        $mysqli = @new \mysqli($db['dbhost'], $db['dbuser'], $db['dbpw'], $db['dbname']);
+        if ($mysqli->connect_error) {
+            return;
+        }
+        $table = $db['tablepre'] . 'common_member';
+        $stmt = $mysqli->prepare("SELECT username,password FROM $table WHERE uid = ?");
+        if (!$stmt) {
+            $mysqli->close();
+            return;
+        }
+        $stmt->bind_param('i', $uid);
+        $stmt->execute();
+        $stmt->bind_result($username, $hash);
+        $stmt->fetch();
+        $stmt->close();
+        $mysqli->close();
+        if ($hash !== $password) {
+            return;
+        }
+        $adminModel = new AdminModel();
+        if (!$adminModel->userExists($username)) {
+            $adminModel->create([
+                'username' => $username,
+                'password' => uniqid(),
+                'translations' => (stripos($_SERVER['HTTP_ACCEPT_LANGUAGE'], 'zh') === false) ? 'en_EN' : 'zh_CN',
+                'admin' => false
+            ]);
+        }
+        session_regenerate_id(true);
+        $_SESSION['PREV_USERAGENT'] = $_SERVER['HTTP_USER_AGENT'];
+        $_SESSION['Username'] = $username;
+        $_SESSION['Active'] = true;
+    }
+
+    private static function authcode($string, $operation = 'DECODE', $key = '', $expiry = 0)
+    {
+        $ckey_length = 4;
+        $key = md5($key);
+        $keya = md5(substr($key, 0, 16));
+        $keyb = md5(substr($key, 16, 16));
+        $keyc = $ckey_length ? ($operation == 'DECODE' ? substr($string, 0, $ckey_length) : substr(md5(microtime()), -$ckey_length)) : '';
+        $cryptkey = $keya . md5($keya . $keyc);
+        $key_length = strlen($cryptkey);
+        $string = $operation == 'DECODE' ? base64_decode(substr($string, $ckey_length)) : sprintf('%010d', $expiry ? $expiry + time() : 0) . substr(md5($string . $keyb), 0, 16) . $string;
+        $string_length = strlen($string);
+        $result = '';
+        $box = range(0, 255);
+        $rndkey = [];
+        for ($i = 0; $i <= 255; $i++) {
+            $rndkey[$i] = ord($cryptkey[$i % $key_length]);
+        }
+        for ($j = $i = 0; $i < 256; $i++) {
+            $j = ($j + $box[$i] + $rndkey[$i]) % 256;
+            $tmp = $box[$i];
+            $box[$i] = $box[$j];
+            $box[$j] = $tmp;
+        }
+        for ($a = $j = $i = 0; $i < $string_length; $i++) {
+            $a = ($a + 1) % 256;
+            $j = ($j + $box[$a]) % 256;
+            $tmp = $box[$a];
+            $box[$a] = $box[$j];
+            $box[$j] = $tmp;
+            $result .= chr(ord($string[$i]) ^ ($box[($box[$a] + $box[$j]) % 256]));
+        }
+        if ($operation == 'DECODE') {
+            if (((int)substr($result, 0, 10) == 0 || (int)substr($result, 0, 10) - time() > 0) && substr($result, 10, 16) === substr(md5(substr($result, 26) . $keyb), 0, 16)) {
+                return substr($result, 26);
+            } else {
+                return '';
+            }
+        } else {
+            return $keyc . str_replace('=', '', base64_encode($result));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- bridge sessions by reading Discuz `auth` cookie
- call the bridge during DocPHT bootstrap
- fix cookie prefix and auth key handling
- query Discuz `common_member` table when validating

## Testing
- `php -l src/core/Helper/DiscuzBridge.php`
- `php -l doc.php`


------
https://chatgpt.com/codex/tasks/task_e_68499c1c43988328a6c8f245872289ee