### PR TITLE
Address review feedback

### DIFF
--- a/doc.php
+++ b/doc.php
@@ -74,12 +74,12 @@ $session->preventStealingSession();
 require $constants;
 require $configurationFile;
 
-DiscuzBridge::syncSession();
-
 $loader = new Nette\Loaders\RobotLoader;
 $loader->addDirectory(__DIR__ . '/src');
 $loader->setTempDirectory(__DIR__ . '/temp');
 $loader->register();
+
+DiscuzBridge::syncSession();
 
 $app            = System\App::instance();
 $app->request   = System\Request::instance();

--- a/src/core/Helper/DiscuzBridge.php
+++ b/src/core/Helper/DiscuzBridge.php
@@ -14,7 +14,7 @@ class DiscuzBridge
         if (!file_exists($configPath)) {
             return;
         }
-        include $configPath;
+        require $configPath;
         if (!isset($_config['cookie']['cookiepre']) || !isset($_config['security']['authkey'])) {
             return;
         }
@@ -36,7 +36,7 @@ class DiscuzBridge
             return;
         }
         $db = $_config['db'][1];
-        $mysqli = @new \mysqli($db['dbhost'], $db['dbuser'], $db['dbpw'], $db['dbname']);
+        $mysqli = new \mysqli($db['dbhost'], $db['dbuser'], $db['dbpw'], $db['dbname']);
         if ($mysqli->connect_error) {
             return;
         }
@@ -59,7 +59,8 @@ class DiscuzBridge
         if (!$adminModel->userExists($username)) {
             $adminModel->create([
                 'username' => $username,
-                'password' => uniqid(),
+                // generate a cryptographically secure placeholder password
+                'password' => bin2hex(random_bytes(16)),
                 'translations' => (stripos($_SERVER['HTTP_ACCEPT_LANGUAGE'], 'zh') === false) ? 'en_EN' : 'zh_CN',
                 'admin' => false
             ]);
@@ -70,6 +71,7 @@ class DiscuzBridge
         $_SESSION['Active'] = true;
     }
 
+    // Implementation derived from Discuz! authcode() helper
     private static function authcode($string, $operation = 'DECODE', $key = '', $expiry = 0)
     {
         $ckey_length = 4;


### PR DESCRIPTION
Summary

- 
- Moved the Discuz bridge initialization after the autoloader registration so classes load correctly
- 
- Required Discuz’s configuration file explicitly, removed mysqli error suppression, and used a secure placeholder password for new users
- 
- Documented that the authcode routine is derived from Discuz for clarity and maintainability
- 
- 