### PR TITLE
Add .htaccess for DocPHT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/config/
 .vscode/
 data/
 uc_server/data/
+Data/

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,21 @@
+<IfModule mod_headers.c>
+Header set X-Content-Type-Options "nosniff"
+Header append X-Frame-Options "DENY"
+Header set X-XSS-Protection "1; mode=block"
+Header unset X-Powered-By
+</IfModule>
+
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ doc.php [QSA,L]
+
+Options All -Indexes
+RedirectMatch 404 /\..*$
+
+<FilesMatch "(\.(ya?ml$|json|lock|fla|inc|ini|log|psd|sh|sql|swp)|~)$">
+    Order allow,deny
+    Deny from all
+    Satisfy All
+    # For Apache 2.4 use:  Require all denied
+</FilesMatch>


### PR DESCRIPTION
## Summary
- add DocPHT `.htaccess` that rewrites to `doc.php`
- ignore runtime `Data/` folder

## Testing
- `curl -I http://localhost/`
- `curl -b /tmp/doc_initial_cookies.txt -c doc_cookies.txt -d "Username=admin&Password=adminpass&_token_=$token" http://localhost/login -o /tmp/doc_login3.html -D /tmp/doc_login3.headers`
- `curl -b doc_cookies.txt -L http://localhost/doc.php -o /tmp/doc_home.html -D /tmp/doc_home.headers`


------
https://chatgpt.com/codex/tasks/task_e_68494ee16318832887a5ab284c3d6e8f