### PR TITLE
Add .htaccess for DocPHT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/config/
 .vscode/
 data/
 uc_server/data/
+Data/

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,18 @@
+<IfModule mod_headers.c>
+Header set X-Content-Type-Options "nosniff"
+Header append X-Frame-Options "DENY"
+Header set X-XSS-Protection "1; mode=block"
+Header unset X-Powered-By
+</IfModule>
+
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ doc.php [QSA,L]
+
+Options All -Indexes
+RedirectMatch 404 /\..*$
+
+<FilesMatch "(\.(ya?ml$|json|lock|fla|inc|ini|log|psd|sh|sql|swp)|~)$">
+    Require all denied
+</FilesMatch>


### PR DESCRIPTION
## Summary
- add DocPHT `.htaccess` that rewrites to `doc.php`
- ignore runtime `Data/` folder
- update file protection rules for Apache 2.4

## Testing
- `php -l doc.php`
- `php -l index.php`
- `composer install --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_68494ee16318832887a5ab284c3d6e8f