### PR TITLE
Fix forum_threadimage synchronization

### DIFF
--- a/install/data/install.sql
+++ b/install/data/install.sql
@@ -3129,7 +3129,7 @@ CREATE TABLE pre_forum_threadimage (
   tid int(10) unsigned NOT NULL DEFAULT '0',
   attachment varchar(255) NOT NULL DEFAULT '',
   remote tinyint(1) NOT NULL DEFAULT '0',
-  KEY tid (tid)
+  UNIQUE KEY tid (tid)
 ) ENGINE=InnoDB;
 
 DROP TABLE IF EXISTS pre_forum_threadmod;

--- a/source/class/extend/extend_thread_image.php
+++ b/source/class/extend/extend_thread_image.php
@@ -42,12 +42,12 @@ class extend_thread_image extends extend_thread_base {
 				$threadimage = C::t('forum_attachment_n')->fetch_attachment('tid:'.$tid, $threadimageaid);
 			}
 			$threadimage = daddslashes($threadimage);
-			C::t('forum_threadimage')->insert(array(
-				'tid' => $tid,
-				'attachment' => $threadimage['attachment'],
-				'remote' => $threadimage['remote'],
-			));
-		}
+                        C::t('forum_threadimage')->insert(array(
+                                'tid' => $tid,
+                                'attachment' => $threadimage['attachment'],
+                                'remote' => $threadimage['remote'],
+                        ), false, true);
+                }
 
 		$this->param['values'] = array_merge((array)$this->param['values'], $values);
 		$this->param['param'] = array_merge((array)$this->param['param'], $param);
@@ -109,14 +109,14 @@ class extend_thread_image extends extend_thread_base {
 					$this->param['threadimage'] = C::t('forum_attachment_n')->fetch_max_image('tid:'.$this->thread['tid'], 'tid', $this->thread['tid']);
 				}
 				C::t('forum_threadimage')->delete_by_tid($this->thread['tid']);
-				C::t('forum_threadimage')->insert(array(
-					'tid' => $this->thread['tid'],
-					'attachment' => $this->param['threadimage']['attachment'],
-					'remote' => $this->param['threadimage']['remote'],
-				));
-			}
-		}
-	}
+                                C::t('forum_threadimage')->insert(array(
+                                        'tid' => $this->thread['tid'],
+                                        'attachment' => $this->param['threadimage']['attachment'],
+                                        'remote' => $this->param['threadimage']['remote'],
+                                ), false, true);
+                        }
+                }
+        }
 
 	public function before_deletepost($parameters) {
 		$thread_attachment = $post_attachment = 0;

--- a/source/function/function_delete.php
+++ b/source/function/function_delete.php
@@ -504,17 +504,25 @@ function deleteattach($ids, $idtype = 'aid') {
 		C::t('forum_attachment_n')->delete_attachment($attachtable, $aids);
 	}
 	C::t('forum_attachment')->delete_by_id($idtype, $ids);
-	if($pics) {
-		$albumids = array();
-		C::t('home_pic')->delete($pics);
-		$query = C::t('home_pic')->fetch_all($pics);
-		foreach($query as $album) {
-			if(!in_array($album['albumid'], $albumids)) {
-				C::t('home_album')->update($album['albumid'], array('picnum' => C::t('home_pic')->check_albumpic($album['albumid'])));
-				$albumids[] = $album['albumid'];
-			}
-		}
-	}
+        if($pics) {
+                $albumids = array();
+                C::t('home_pic')->delete($pics);
+                $query = C::t('home_pic')->fetch_all($pics);
+                foreach($query as $album) {
+                        if(!in_array($album['albumid'], $albumids)) {
+                                C::t('home_album')->update($album['albumid'], array('picnum' => C::t('home_pic')->check_albumpic($album['albumid'])));
+                                $albumids[] = $album['albumid'];
+                        }
+                }
+        }
+
+        if($idtype == 'tid') {
+                foreach((array)$ids as $tid) {
+                        if(!C::t('forum_attachment')->count_by_tid($tid)) {
+                                C::t('forum_threadimage')->delete_by_tid($tid);
+                        }
+                }
+        }
 }
 
 function deletecomments($cids) {

--- a/source/module/forum/forum_ajax.php
+++ b/source/module/forum/forum_ajax.php
@@ -263,11 +263,11 @@ if($_GET['action'] == 'checkusername') {
 		if(setthreadcover($pid, $tid, $aid, 0, $imgurl)) {
 			if(empty($imgurl)) {
 				C::t('forum_threadimage')->delete_by_tid($threadimage['tid']);
-				C::t('forum_threadimage')->insert(array(
-					'tid' => $threadimage['tid'],
-					'attachment' => $threadimage['attachment'],
-					'remote' => $threadimage['remote'],
-				));
+                                C::t('forum_threadimage')->insert(array(
+                                        'tid' => $threadimage['tid'],
+                                        'attachment' => $threadimage['attachment'],
+                                        'remote' => $threadimage['remote'],
+                                ), false, true);
 			}
 			if($_GET['newthread']) {
 				showmessage('set_cover_succeed', '', array(), array('msgtype' => 3));

--- a/tests/threadimage_sync.php
+++ b/tests/threadimage_sync.php
@@ -1,0 +1,66 @@
+<?php
+require __DIR__ . '/../config/config_global.php';
+require_once __DIR__ . '/../source/class/class_core.php';
+$discuz = C::app();
+$discuz->init();
+require_once libfile('function/delete');
+require_once libfile('function/forum');
+
+$tid = 20001;
+$uid = 1;
+
+// insert attachment metadata
+$aid = C::t('forum_attachment')->insert([
+    'tid' => $tid,
+    'pid' => 0,
+    'uid' => $uid,
+    'tableid' => 0,
+    'downloads' => 0,
+], true);
+
+// insert attachment content row
+C::t('forum_attachment_n')->insert_attachment(0, [
+    'aid' => $aid,
+    'tid' => $tid,
+    'pid' => 0,
+    'uid' => $uid,
+    'dateline' => time(),
+    'filename' => 'test.jpg',
+    'filesize' => 1234,
+    'attachment' => 'test.jpg',
+    'remote' => 0,
+    'description' => '',
+    'readperm' => 0,
+    'price' => 0,
+    'isimage' => 1,
+    'width' => 0,
+    'height' => 0,
+    'thumb' => 0,
+    'picid' => 0,
+    'sha1' => '',
+]);
+
+// threadimage entry
+C::t('forum_threadimage')->insert([
+    'tid' => $tid,
+    'attachment' => 'test.jpg',
+    'remote' => 0,
+], false, true);
+
+$beforeAttachments = C::t('forum_attachment')->count_by_tid($tid);
+$beforeThreadimage = DB::result_first('SELECT COUNT(*) FROM %t WHERE tid=%d', ['forum_threadimage', $tid]);
+
+echo "Before delete: attachments=$beforeAttachments, threadimage=$beforeThreadimage\n";
+
+deleteattach($tid, 'tid');
+
+$afterAttachments = C::t('forum_attachment')->count_by_tid($tid);
+$afterThreadimage = DB::result_first('SELECT COUNT(*) FROM %t WHERE tid=%d', ['forum_threadimage', $tid]);
+
+echo "After delete: attachments=$afterAttachments, threadimage=$afterThreadimage\n";
+
+if ($afterAttachments == 0 && $afterThreadimage == 0) {
+    echo "SYNC_OK\n";
+} else {
+    echo "SYNC_FAIL\n";
+}

--- a/tools/fix_threadimage.sql
+++ b/tools/fix_threadimage.sql
@@ -1,0 +1,49 @@
+USE ultrax;
+
+-- remove threadimage entries that have no matching attachment
+DELETE ti FROM pre_forum_threadimage ti
+LEFT JOIN (
+    SELECT tid FROM pre_forum_attachment_0
+    UNION SELECT tid FROM pre_forum_attachment_1
+    UNION SELECT tid FROM pre_forum_attachment_2
+    UNION SELECT tid FROM pre_forum_attachment_3
+    UNION SELECT tid FROM pre_forum_attachment_4
+    UNION SELECT tid FROM pre_forum_attachment_5
+    UNION SELECT tid FROM pre_forum_attachment_6
+    UNION SELECT tid FROM pre_forum_attachment_7
+    UNION SELECT tid FROM pre_forum_attachment_8
+    UNION SELECT tid FROM pre_forum_attachment_9
+) a ON ti.tid=a.tid
+WHERE a.tid IS NULL;
+
+-- update existing records based on latest attachment
+-- table 0
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_0 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_0 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=0;
+
+-- table 1
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_1 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_1 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=1;
+
+-- table 2
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_2 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_2 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=2;
+
+-- table 3
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_3 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_3 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=3;
+
+-- table 4
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_4 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_4 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=4;
+
+-- table 5
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_5 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_5 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=5;
+
+-- table 6
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_6 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_6 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=6;
+
+-- table 7
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_7 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_7 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=7;
+
+-- table 8
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_8 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_8 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=8;
+
+-- table 9
+UPDATE pre_forum_threadimage ti JOIN (SELECT a.tid, a.attachment, a.remote FROM pre_forum_attachment_9 a JOIN (SELECT tid, MAX(aid) AS aid FROM pre_forum_attachment_9 GROUP BY tid) m ON a.tid=m.tid AND a.aid=m.aid) u ON ti.tid=u.tid SET ti.attachment=u.attachment, ti.remote=u.remote WHERE ti.tid%10=9;
+


### PR DESCRIPTION
## Summary
- ensure deleting attachments removes forum_threadimage entries when no images remain
- replace existing threadimage row when setting covers or creating threads
- enforce unique tid index in threadimage table
- add CLI test verifying threadimage sync after attachment deletion
- provide SQL script to update existing threadimage rows

## Testing
- `php -l source/module/forum/forum_ajax.php`
- `php -l source/class/extend/extend_thread_image.php`
- `php -l source/function/function_delete.php`
- `php -l tests/threadimage_sync.php`
- `php tests/threadimage_sync.php`
- `mysql -uroot < tools/fix_threadimage.sql`


------
https://chatgpt.com/codex/tasks/task_e_684a357856a48328a5425834f4337988