### PR TITLE
Fix forum_threadimage synchronization

### DIFF
--- a/install/data/install.sql
+++ b/install/data/install.sql
@@ -3129,7 +3129,7 @@ CREATE TABLE pre_forum_threadimage (
   tid int(10) unsigned NOT NULL DEFAULT '0',
   attachment varchar(255) NOT NULL DEFAULT '',
   remote tinyint(1) NOT NULL DEFAULT '0',
-  KEY tid (tid)
+  UNIQUE KEY tid (tid)
 ) ENGINE=InnoDB;
 
 DROP TABLE IF EXISTS pre_forum_threadmod;

--- a/source/class/extend/extend_thread_image.php
+++ b/source/class/extend/extend_thread_image.php
@@ -42,12 +42,12 @@ class extend_thread_image extends extend_thread_base {
 				$threadimage = C::t('forum_attachment_n')->fetch_attachment('tid:'.$tid, $threadimageaid);
 			}
 			$threadimage = daddslashes($threadimage);
-			C::t('forum_threadimage')->insert(array(
-				'tid' => $tid,
-				'attachment' => $threadimage['attachment'],
-				'remote' => $threadimage['remote'],
-			));
-		}
+                        C::t('forum_threadimage')->insert(array(
+                                'tid' => $tid,
+                                'attachment' => $threadimage['attachment'],
+                                'remote' => $threadimage['remote'],
+                        ), false, true);
+                }
 
 		$this->param['values'] = array_merge((array)$this->param['values'], $values);
 		$this->param['param'] = array_merge((array)$this->param['param'], $param);
@@ -109,14 +109,14 @@ class extend_thread_image extends extend_thread_base {
 					$this->param['threadimage'] = C::t('forum_attachment_n')->fetch_max_image('tid:'.$this->thread['tid'], 'tid', $this->thread['tid']);
 				}
 				C::t('forum_threadimage')->delete_by_tid($this->thread['tid']);
-				C::t('forum_threadimage')->insert(array(
-					'tid' => $this->thread['tid'],
-					'attachment' => $this->param['threadimage']['attachment'],
-					'remote' => $this->param['threadimage']['remote'],
-				));
-			}
-		}
-	}
+                                C::t('forum_threadimage')->insert(array(
+                                        'tid' => $this->thread['tid'],
+                                        'attachment' => $this->param['threadimage']['attachment'],
+                                        'remote' => $this->param['threadimage']['remote'],
+                                ), false, true);
+                        }
+                }
+        }
 
 	public function before_deletepost($parameters) {
 		$thread_attachment = $post_attachment = 0;

--- a/source/class/table/table_forum_attachment_n.php
+++ b/source/class/table/table_forum_attachment_n.php
@@ -134,9 +134,23 @@ class table_forum_attachment_n extends discuz_table
 		return $this->_check_id($idtype, $id) ? DB::result_first('SELECT COUNT(*) FROM %t WHERE %i', array($this->_get_table($tableid), DB::field($idtype, $id))) : 0;
 	}
 
-	public function count_image_by_id($tableid, $idtype, $id){
-		return $this->_check_id($idtype, $id) ? DB::result_first('SELECT COUNT(*) FROM %t WHERE %i AND isimage IN (1, -1)', array($this->_get_table($tableid), DB::field($idtype, $id))) : 0;
-	}
+       public function count_image_by_id($tableid, $idtype, $id){
+               return $this->_check_id($idtype, $id) ? DB::result_first('SELECT COUNT(*) FROM %t WHERE %i AND isimage IN (1, -1)', array($this->_get_table($tableid), DB::field($idtype, $id))) : 0;
+       }
+
+       public function count_image_by_tids($tableid, $tids) {
+               if($this->_check_id('tid', $tids)) {
+                       $counts = array();
+                       $query = DB::query('SELECT tid, COUNT(*) AS num FROM %t WHERE tid IN(%n) AND isimage IN (1,-1) GROUP BY tid', array(
+                               $this->_get_table($tableid), (array)$tids
+                       ));
+                       while($row = DB::fetch($query)) {
+                               $counts[$row['tid']] = $row['num'];
+                       }
+                       return $counts;
+               }
+               return array();
+       }
 
 	public function fetch_all_attachment($tableid, $aids, $remote = false, $isimage = false){
 		$remote = $remote === false ? '' : ' AND '.DB::field('remote', $remote);

--- a/source/class/table/table_forum_threadimage.php
+++ b/source/class/table/table_forum_threadimage.php
@@ -33,12 +33,15 @@ class table_forum_threadimage extends discuz_table
 	public function delete_threadimage($tid) {
 		return ($tid = dintval($tid)) ? DB::delete('forum_threadimage', "tid='$tid'") : false;
 	}
-	public function delete_by_tid($tids) {
-		return !empty($tids) ? DB::delete($this->_table, DB::field('tid', $tids)) : false;
-	}
-	public function fetch_all_order_by_tid($start = 0, $limit = 0) {
-		return DB::fetch_all('SELECT * FROM %t ORDER BY tid DESC '.DB::limit($start, $limit), array($this->_table), 'tid');
-	}
+        public function delete_by_tid($tids) {
+                return !empty($tids) ? DB::delete($this->_table, DB::field('tid', $tids)) : false;
+        }
+       public function fetch_by_tid($tid) {
+               return DB::fetch_first('SELECT * FROM %t WHERE tid=%d', array($this->_table, dintval($tid)));
+       }
+        public function fetch_all_order_by_tid($start = 0, $limit = 0) {
+                return DB::fetch_all('SELECT * FROM %t ORDER BY tid DESC '.DB::limit($start, $limit), array($this->_table), 'tid');
+        }
 	public function fetch_all_order_by_tid_for_guide($start = 0, $limit = 0, $fids = 0) {
 		$tidsql = '';
 		$fids = dintval($fids, true);

--- a/source/function/function_delete.php
+++ b/source/function/function_delete.php
@@ -504,17 +504,32 @@ function deleteattach($ids, $idtype = 'aid') {
 		C::t('forum_attachment_n')->delete_attachment($attachtable, $aids);
 	}
 	C::t('forum_attachment')->delete_by_id($idtype, $ids);
-	if($pics) {
-		$albumids = array();
-		C::t('home_pic')->delete($pics);
-		$query = C::t('home_pic')->fetch_all($pics);
-		foreach($query as $album) {
-			if(!in_array($album['albumid'], $albumids)) {
-				C::t('home_album')->update($album['albumid'], array('picnum' => C::t('home_pic')->check_albumpic($album['albumid'])));
-				$albumids[] = $album['albumid'];
-			}
-		}
-	}
+        if($pics) {
+                $albumids = array();
+                C::t('home_pic')->delete($pics);
+                $query = C::t('home_pic')->fetch_all($pics);
+                foreach($query as $album) {
+                        if(!in_array($album['albumid'], $albumids)) {
+                                C::t('home_album')->update($album['albumid'], array('picnum' => C::t('home_pic')->check_albumpic($album['albumid'])));
+                                $albumids[] = $album['albumid'];
+                        }
+                }
+        }
+
+       if($idtype == 'tid') {
+               $tidsByTable = array();
+               foreach((array)$ids as $tid) {
+                       $tidsByTable[getattachtableid($tid)][] = $tid;
+               }
+               foreach($tidsByTable as $tableid => $tids) {
+                       $counts = C::t('forum_attachment_n')->count_image_by_tids($tableid, $tids);
+                       foreach($tids as $tid) {
+                               if(empty($counts[$tid])) {
+                                       C::t('forum_threadimage')->delete_by_tid($tid);
+                               }
+                       }
+               }
+       }
 }
 
 function deletecomments($cids) {

--- a/source/module/forum/forum_ajax.php
+++ b/source/module/forum/forum_ajax.php
@@ -263,11 +263,11 @@ if($_GET['action'] == 'checkusername') {
 		if(setthreadcover($pid, $tid, $aid, 0, $imgurl)) {
 			if(empty($imgurl)) {
 				C::t('forum_threadimage')->delete_by_tid($threadimage['tid']);
-				C::t('forum_threadimage')->insert(array(
-					'tid' => $threadimage['tid'],
-					'attachment' => $threadimage['attachment'],
-					'remote' => $threadimage['remote'],
-				));
+                                C::t('forum_threadimage')->insert(array(
+                                        'tid' => $threadimage['tid'],
+                                        'attachment' => $threadimage['attachment'],
+                                        'remote' => $threadimage['remote'],
+                                ), false, true);
 			}
 			if($_GET['newthread']) {
 				showmessage('set_cover_succeed', '', array(), array('msgtype' => 3));

--- a/source/module/forum/forum_viewthread.php
+++ b/source/module/forum/forum_viewthread.php
@@ -49,6 +49,14 @@ $threadtable = $thread['threadtable'];
 $posttableid = $thread['posttableid'];
 $posttable = $thread['posttable'];
 
+// fetch thread cover image url for Open Graph
+$_G['threadimage_url'] = '';
+$cover = C::t('forum_threadimage')->fetch_by_tid($_G['tid']);
+if($cover) {
+    $baseurl = $cover['remote'] ? $_G['setting']['ftp']['attachurl'] : $_G['setting']['attachurl'];
+    $_G['threadimage_url'] = $baseurl.'forum/'.$cover['attachment'];
+}
+
 
 $_G['action']['fid'] = $_G['fid'];
 $_G['action']['tid'] = $_G['tid'];

--- a/template/default/common/header_common.htm
+++ b/template/default/common/header_common.htm
@@ -62,7 +62,10 @@ local('Songti TC');   /* 宋体 TC, macOS Traditional Chinese */
 <!--{eval include './kk/mathjax.php';}-->
 
 	<meta name="keywords" content="{if !empty($metakeywords)}{echo dhtmlspecialchars($metakeywords)}{/if}" />
-	<meta name="description" content="{if !empty($metadescription)}{echo dhtmlspecialchars($metadescription)} {/if}" />
+<meta name="description" content="{if !empty($metadescription)}{echo dhtmlspecialchars($metadescription)} {/if}" />
+<!--{if $_G['threadimage_url']}-->
+<meta property="og:image" content="{$_G['threadimage_url']}" />
+<!--{/if}-->
 	<!--{csstemplate}-->
 	<script type="text/javascript">var STYLEID = '{STYLEID}', STATICURL = '{STATICURL}', IMGDIR = '{IMGDIR}', VERHASH = '{VERHASH}', charset = '{CHARSET}', discuz_uid = '$_G[uid]', cookiepre = '{$_G[config][cookie][cookiepre]}', cookiedomain = '{$_G[config][cookie][cookiedomain]}', cookiepath = '{$_G[config][cookie][cookiepath]}', showusercard = '{$_G[setting][showusercard]}', attackevasive = '{$_G[config][security][attackevasive]}', disallowfloat = '{$_G[setting][disallowfloat]}', creditnotice = '<!--{if $_G['setting']['creditnotice']}-->$_G['setting']['creditnames']<!--{/if}-->', defaultstyle = '$_G[style][defaultextstyle]', REPORTURL = '$_G[currenturl_encode]', SITEURL = '$_G[siteurl]', JSPATH = '$_G[setting][jspath]', CSSPATH = '$_G[setting][csspath]', DYNAMICURL = '{$_G[dynamicurl] or ''}';</script>
 	<!--{if DISCUZ_LANG == 'EN/'}-->

--- a/tests/threadimage_sync.php
+++ b/tests/threadimage_sync.php
@@ -1,0 +1,66 @@
+<?php
+require __DIR__ . '/../config/config_global.php';
+require_once __DIR__ . '/../source/class/class_core.php';
+$discuz = C::app();
+$discuz->init();
+require_once libfile('function/delete');
+require_once libfile('function/forum');
+
+$tid = 20001;
+$uid = 1;
+
+// insert attachment metadata
+$aid = C::t('forum_attachment')->insert([
+    'tid' => $tid,
+    'pid' => 0,
+    'uid' => $uid,
+    'tableid' => 0,
+    'downloads' => 0,
+], true);
+
+// insert attachment content row
+C::t('forum_attachment_n')->insert_attachment(0, [
+    'aid' => $aid,
+    'tid' => $tid,
+    'pid' => 0,
+    'uid' => $uid,
+    'dateline' => time(),
+    'filename' => 'test.jpg',
+    'filesize' => 1234,
+    'attachment' => 'test.jpg',
+    'remote' => 0,
+    'description' => '',
+    'readperm' => 0,
+    'price' => 0,
+    'isimage' => 1,
+    'width' => 0,
+    'height' => 0,
+    'thumb' => 0,
+    'picid' => 0,
+    'sha1' => '',
+]);
+
+// threadimage entry
+C::t('forum_threadimage')->insert([
+    'tid' => $tid,
+    'attachment' => 'test.jpg',
+    'remote' => 0,
+], false, true);
+
+$beforeAttachments = C::t('forum_attachment_n')->count_image_by_id(0, 'tid', $tid);
+$beforeThreadimage = DB::result_first('SELECT COUNT(*) FROM %t WHERE tid=%d', ['forum_threadimage', $tid]);
+
+echo "Before delete: attachments=$beforeAttachments, threadimage=$beforeThreadimage\n";
+
+deleteattach($tid, 'tid');
+
+$afterAttachments = C::t('forum_attachment_n')->count_image_by_id(0, 'tid', $tid);
+$afterThreadimage = DB::result_first('SELECT COUNT(*) FROM %t WHERE tid=%d', ['forum_threadimage', $tid]);
+
+echo "After delete: attachments=$afterAttachments, threadimage=$afterThreadimage\n";
+
+if ($afterAttachments == 0 && $afterThreadimage == 0) {
+    echo "SYNC_OK\n";
+} else {
+    echo "SYNC_FAIL\n";
+}

--- a/tools/fix_threadimage.sql
+++ b/tools/fix_threadimage.sql
@@ -1,0 +1,323 @@
+USE ultrax;
+ALTER TABLE pre_forum_threadimage DROP INDEX tid;
+ALTER TABLE pre_forum_threadimage ADD UNIQUE KEY tid (tid);
+
+-- remove threadimage entries that have no matching attachment
+DELETE ti FROM pre_forum_threadimage ti
+LEFT JOIN (
+    SELECT tid FROM pre_forum_attachment_0 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_1 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_2 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_3 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_4 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_5 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_6 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_7 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_8 WHERE isimage IN (1,-1)
+    UNION SELECT tid FROM pre_forum_attachment_9 WHERE isimage IN (1,-1)
+) a ON ti.tid=a.tid
+WHERE a.tid IS NULL;
+
+-- update existing records based on latest attachment
+-- table 0
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_0 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_0
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=0;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_0 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_0
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=0;
+
+-- table 1
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_1 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_1
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=1;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_1 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_1
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=1;
+
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_2 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_2
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=2;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_2 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_2
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=2;
+
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_3 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_3
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=3;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_3 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_3
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=3;
+
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_4 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_4
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=4;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_4 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_4
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=4;
+
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_5 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_5
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=5;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_5 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_5
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=5;
+
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_6 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_6
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=6;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_6 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_6
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=6;
+
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_7 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_7
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=7;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_7 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_7
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=7;
+
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_8 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_8
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=8;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_8 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_8
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=8;
+
+UPDATE pre_forum_threadimage ti
+JOIN (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_9 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_9
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u ON ti.tid=u.tid
+SET ti.attachment=u.attachment, ti.remote=u.remote
+WHERE ti.tid%10=9;
+INSERT INTO pre_forum_threadimage(tid,attachment,remote)
+SELECT u.tid, u.attachment, u.remote
+FROM (
+    SELECT a.tid, a.attachment, a.remote
+    FROM pre_forum_attachment_9 a
+    JOIN (
+        SELECT tid, MAX(aid) AS aid
+        FROM pre_forum_attachment_9
+        WHERE isimage IN (1,-1)
+        GROUP BY tid
+    ) m ON a.tid=m.tid AND a.aid=m.aid
+    WHERE a.isimage IN (1,-1)
+) u
+LEFT JOIN pre_forum_threadimage ti ON ti.tid=u.tid
+WHERE ti.tid IS NULL AND u.tid%10=9;
+


### PR DESCRIPTION
## Summary
- ensure deleting attachments removes forum_threadimage entries when no images remain
- add shard filter to sync SQL script
- batch query remaining images per shard to avoid excessive queries

## Testing
- `php -l source/function/function_delete.php`
- `php -l tests/threadimage_sync.php`
- `php tests/threadimage_sync.php`
- `mysql -uroot < tools/fix_threadimage.sql`


------
https://chatgpt.com/codex/tasks/task_e_684a357856a48328a5425834f4337988