### PR TITLE
Show thread excerpts on desktop

### DIFF
--- a/source/function/function_forumlist.php
+++ b/source/function/function_forumlist.php
@@ -424,11 +424,13 @@ function threadclasscount($fid, $id = 0, $idtype = '', $count = null) {
 
 }
 
-function get_attach($list, $video = false, $audio = false){
+// Build post excerpts and optionally attachment thumbnails for a thread list
+// $withattach controls whether image attachments are fetched
+function get_attach($list, $video = false, $audio = false, $withattach = true){
 	global $_G;
 	require_once libfile('function/post');
 	require_once libfile('function/discuzcode');
-	$tids = $threads = $attachtableid_array = $threadlist_data = $posttableids = array();
+        $tids = $threads = $attachtableid_array = $threadlist_data = $posttableids = array();
 	foreach($list as $value) {
 		$tids[] = $value['tid'];
 		if(!in_array($value['posttableid'], $posttableids)){
@@ -467,19 +469,21 @@ function get_attach($list, $video = false, $audio = false){
 						$threadlist_data[$value['tid']]['media'] = parseaudio($value['audio'][2], 400);
 					}
 				}
-				$threadlist_data[$value['tid']]['message'] = dhtmlspecialchars(messagecutstr($value['message'], 300, null, $firstpost['htmlon']));
-				if($threads[$value['tid']]['attachment'] == 2) {
-					$attachtableid_array[getattachtableid($value['tid'])][] = $value['pid'];
-				}
+                                $threadlist_data[$value['tid']]['message'] = dhtmlspecialchars(messagecutstr($value['message'], 300, null, $firstpost['htmlon']));
+                                if($withattach && $threads[$value['tid']]['attachment'] == 2) {
+                                        $attachtableid_array[getattachtableid($value['tid'])][] = $value['pid'];
+                                }
 			}
 		}
 	}
-	foreach($attachtableid_array as $tableid => $pids) {
-		$attachs = C::t('forum_attachment_n')->fetch_all_by_pid_width($tableid, $pids, 0);
-		foreach($attachs as $value){
-			$threadlist_data[$value['tid']]['attachment'][] = getforumimg($value['aid'], 0, 550, 350);
-		}
-	}
+        if($withattach) {
+                foreach($attachtableid_array as $tableid => $pids) {
+                        $attachs = C::t('forum_attachment_n')->fetch_all_by_pid_width($tableid, $pids, 0);
+                        foreach($attachs as $value){
+                                $threadlist_data[$value['tid']]['attachment'][] = getforumimg($value['aid'], 0, 550, 350);
+                        }
+                }
+        }
 	return $threadlist_data;
 }
 ?>

--- a/source/module/forum/forum_forumdisplay.php
+++ b/source/module/forum/forum_forumdisplay.php
@@ -992,8 +992,9 @@ if($_G['forum']['status'] == 3) {
 }
 
 $threadlist_data = array();
-if(defined('IN_MOBILE') && $_G['forum_threadcount']) {
-	$threadlist_data = get_attach($_G['forum_threadlist']);
+if($_G['forum_threadcount']) {
+        // Desktop thread list only needs excerpts, skip fetching attachments
+        $threadlist_data = get_attach($_G['forum_threadlist'], false, false, false);
 }
 if(!defined('IN_ARCHIVER')) {
 	include template($template);

--- a/template/default/forum/forumdisplay_list.htm
+++ b/template/default/forum/forumdisplay_list.htm
@@ -224,10 +224,13 @@
 											<!--{/if}-->
 										<!--{/if}-->
 										<!--{if $thread[taglist]}-->
-										<div class="thread-tags">
-												<!--{loop $thread[taglist] $tag}--><span class="tag-item"><a href="misc.php?mod=tag&id=$tag[tagid]&name={echo urlencode($tag[tagname])}" target="_blank">$tag[tagname]</a></span><!--{/loop}-->
-										</div>
-										<!--{/if}-->
+                                        <div class="thread-tags">
+                                        <!--{loop $thread[taglist] $tag}--><span class="tag-item"><a href="misc.php?mod=tag&id=$tag[tagid]&name={echo urlencode($tag[tagname])}" target="_blank">$tag[tagname]</a></span><!--{/loop}-->
+                                        </div>
+                                        <!--{/if}-->
+                                        <!--{if $threadlist_data[$thread['tid']]['message'] && !in_array($thread['displayorder'], array(1,2,3,4))}-->
+                                        <p class="xg1">{$threadlist_data[$thread['tid']]['message']}</p>
+                                        <!--{/if}-->
 									</th>
 									<!--{if CURMODULE == 'guide'}-->
 										<td class="by"><a href="forum.php?mod=forumdisplay&fid=$thread[fid]" target="_blank">$forumnames[$thread[fid]]['name']</a></td>
@@ -294,8 +297,11 @@
 								<h3 class="xw0">
 									<!--{hook/forumdisplay_thread $key}-->
 									<a href="forum.php?mod=viewthread&tid=$thread[tid]&{if $_GET['archiveid']}archiveid={$_GET['archiveid']}&{/if}extra=$extra"$thread[highlight]{if $thread['isgroup'] == 1 || $thread['forumstick']} target="_blank"{else} onclick="atarget(this)"{/if} title="$thread[subject]">$thread[subject]</a>
-								</h3>
-								<div class="auth cl">
+                                                                </h3>
+                                                                <!--{if $threadlist_data[$thread['tid']]['message'] && !in_array($thread['displayorder'], array(1,2,3,4))}-->
+                                                                <p class="xg1">{$threadlist_data[$thread['tid']]['message']}</p>
+                                                                <!--{/if}-->
+                                                                <div class="auth cl">
 									<cite class="xg1 y">
 										{lang like}: <!--{if $thread[recommends]}-->$thread[recommends]<!--{else}-->0<!--{/if}-->
 										 &nbsp; {lang reply}: <a href="forum.php?mod=viewthread&tid=$thread[tid]&extra=$extra" title="$thread[replies] {lang reply}">$thread[replies]</a>


### PR DESCRIPTION
## Summary
- display first post excerpt in desktop forum thread list
- build thread excerpt data for all views, not only mobile
- skip attachment processing for desktop lists to reduce overhead
- hide excerpts for announcement threads

## Testing
- `curl -s 127.0.0.1/forum.php?mod=forumdisplay\&fid=5 > /tmp/out.html`
- `tidy -qe /tmp/out.html`

------
https://chatgpt.com/codex/tasks/task_e_684c10e9f61483288bb6e7366d43ee57