### PR TITLE
Update lastposter on new reply comments

### DIFF
--- a/source/include/post/post_newreply.php
+++ b/source/include/post/post_newreply.php
@@ -97,7 +97,7 @@ if($_G['setting']['commentnumber'] && !empty($_GET['comment'])) {
 	C::t('forum_post')->update_post('tid:'.$_G['tid'], $_GET['pid'], array('comment' => 1));
 	$comment = cutstr(str_replace(array('[b]', '[/b]', '[/color]'), '', preg_replace("/\[color=([#\w]+?)\]/i", "", $comment)), 200);
 	$comments = $thread['comments'] ? $thread['comments'] + 1 : C::t('forum_postcomment')->count_by_tid($_G['tid']);
-	C::t('forum_thread')->update($_G['tid'], array('comments' => $comments, 'lastpost' => TIMESTAMP));
+        C::t('forum_thread')->update($_G['tid'], array('comments' => $comments, 'lastpost' => TIMESTAMP, 'lastposter' => $_G['username']));
 	if(!empty($_G['uid']) && $_G['uid'] != $post['authorid']) {
 		notification_add($post['authorid'], 'pcomment', 'comment_add', array(
 			'tid' => $_G['tid'],


### PR DESCRIPTION
## Summary
- keep track of the commenter when updating thread meta data


------
https://chatgpt.com/codex/tasks/task_e_68504f02bd4083289dda50490c3a911c