### PR TITLE
Fix Discuz cookie prefix detection

### DIFF
--- a/src/core/Helper/DiscuzBridge.php
+++ b/src/core/Helper/DiscuzBridge.php
@@ -40,12 +40,26 @@ class DiscuzBridge
             return;
         }
         $cookiePre = $_config['cookie']['cookiepre'] .
-            substr(md5($_config['cookie']['cookiepath'] . '|' . $_config['cookie']['cookiedomain']), 0, 4) .
+            substr(md5(
+                $_config['cookie']['cookiepath'] . '|' . $_config['cookie']['cookiedomain']
+            ), 0, 4) .
             '_';
         $authCookie = $cookiePre . 'auth';
         $saltCookie = $cookiePre . 'saltkey';
         if (empty($_COOKIE[$authCookie]) || empty($_COOKIE[$saltCookie])) {
-            return;
+            foreach (array_keys($_COOKIE) as $name) {
+                if (preg_match('/^(.+_)?auth$/', $name, $m)) {
+                    $prefix = $m[1] ?? '';
+                    if (isset($_COOKIE[$prefix . 'saltkey'])) {
+                        $authCookie = $prefix . 'auth';
+                        $saltCookie = $prefix . 'saltkey';
+                        break;
+                    }
+                }
+            }
+            if (empty($_COOKIE[$authCookie]) || empty($_COOKIE[$saltCookie])) {
+                return;
+            }
         }
         $authkey = md5($_config['security']['authkey'] . $_COOKIE[$saltCookie]);
         $rawAuth = rawurldecode($_COOKIE[$authCookie]);

--- a/tests/check_discuz_login.php
+++ b/tests/check_discuz_login.php
@@ -2,6 +2,7 @@
 // Quick script to verify Discuz login status
 define('DISCUZ_BRIDGE_DEBUG', true);
 require __DIR__ . '/../src/core/constants.php';
+require __DIR__ . '/../vendor/autoload.php';
 require __DIR__ . '/../src/core/Helper/DiscuzBridge.php';
 DocPHT\Core\Helper\DiscuzBridge::syncSession();
 require __DIR__ . '/../config/config_global.php';


### PR DESCRIPTION
## Summary
- scan cookies to detect Discuz prefix if configured prefix not found
- load vendor autoload in check_discuz_login test script

## Testing
- `php -l src/core/Helper/DiscuzBridge.php`
- `php -l tests/check_discuz_login.php`


------
https://chatgpt.com/codex/tasks/task_e_6850a6f5cbb083288f3a6556c0f2c44c