### PR TITLE
Apply upstream fix for unused attachment cleanup

### DIFF
--- a/source/class/table/table_forum_attachment_unused.php
+++ b/source/class/table/table_forum_attachment_unused.php
@@ -24,16 +24,15 @@ class table_forum_attachment_unused extends discuz_table
 	public function clear() {
 		require_once libfile('function/forum');
 		$delaids = array();
-		$query = DB::query("SELECT aid, attachment, thumb FROM %t WHERE %i", array($this->_table, DB::field('dateline', TIMESTAMP - 86400)));
-		while($attach = DB::fetch($query)) {
-			updatemembercount($attach['uid'], array('todayattachs' => -1, 'todayattachsize' => -$attach['filesize'], 'attachsize' => -$attach['filesize']), false);
-			dunlink($attach);
-			$delaids[] = $attach['aid'];
-		}
-		if($delaids) {
-			DB::query("DELETE FROM %t WHERE %i", array('forum_attachment', DB::field('aid', $delaids)), false, true);
-			DB::query("DELETE FROM %t WHERE %i", array($this->_table, DB::field('dateline', TIMESTAMP - 86400)), false, true);
-		}
+               $query = DB::query("SELECT aid, attachment, thumb FROM %t WHERE %i", array($this->_table, DB::field('dateline', TIMESTAMP - 86400, '<')));
+               while($attach = DB::fetch($query)) {
+                       dunlink($attach);
+                       $delaids[] = $attach['aid'];
+               }
+               if($delaids) {
+                       DB::query("DELETE FROM %t WHERE %i", array('forum_attachment', DB::field('aid', $delaids)), false, true);
+                       DB::query("DELETE FROM %t WHERE %i", array($this->_table, DB::field('dateline', TIMESTAMP - 86400, '<')), false, true);
+               }
 	}
 
 }


### PR DESCRIPTION
## Summary
- apply upstream commit to adjust unused attachment cleanup logic

## Testing
- `git status --porcelain`

------
https://chatgpt.com/codex/tasks/task_e_6850b81e54248328b091640e1d2fd5a6