### PR TITLE
Sync showmessage.htm style with upstream

### DIFF
--- a/template/default/touch/common/showmessage.htm
+++ b/template/default/touch/common/showmessage.htm
@@ -1,21 +1,21 @@
 <!--{if $param['login']}-->
-	<!--{if $_G['inajax']}-->
-	<!--{eval dheader('Location:member.php?mod=logging&action=login&inajax=1&infloat=1');exit;}-->
-	<!--{else}-->
-	<!--{eval dheader('Location:member.php?mod=logging&action=login');exit;}-->
-	<!--{/if}-->
+<!--{if $_G['inajax']}-->
+<!--{eval dheader('Location:member.php?mod=logging&action=login&inajax=1&infloat=1');exit;}-->
+<!--{else}-->
+<!--{eval dheader('Location:member.php?mod=logging&action=login');exit;}-->
+<!--{/if}-->
 <!--{/if}-->
 <!--{template common/header}-->
 <!--{if $_G['inajax']}-->
 <div class="tip">
 	<dt id="messagetext">
 		<p>$show_message</p>
-        <!--{if $_G['forcemobilemessage']}-->
-        <p>
+		<!--{if $_G['forcemobilemessage']}-->
+		<p>
 			<a href="{$_G['setting']['mobile']['pageurl']}" class="mtn">{lang continue}</a><br />
 			<a href="javascript:history.back();">{lang goback}</a>
 		</p>
-        <!--{/if}-->
+		<!--{/if}-->
 		<!--{if $url_forward && !$_GET['loc']}-->
 		<script type="text/javascript">
 			setTimeout(function() {
@@ -23,8 +23,8 @@
 			}, '3000');
 		</script>
 		<!--{elseif $allowreturn}-->
-		<dd><input type="button" class="close pn" onclick="popup.close();" value="{lang close}"></dd>
-		<!--{/if}-->
+	<dd><input type="button" class="close pn" onclick="popup.close();" value="{lang close}"></dd>
+	<!--{/if}-->
 	</dt>
 </div>
 <!--{else}-->
@@ -34,17 +34,17 @@
 	<div class="my"><a href="index.php"><i class="dm-house"></i></a></div>
 </div>
 <div class="jump_c">
-	<p>$show_message</p>
+	<div>$show_message</div>
 	<!--{if $_G['forcemobilemessage']}-->
-	<p class="mt10">
+	<div class="mt10">
 		<a href="{$_G['setting']['mobile']['pageurl']}">{lang continue}</a><br />
 		<a href="javascript:history.back();">{lang goback}</a>
-	</p>
+	</div>
 	<!--{/if}-->
 	<!--{if $url_forward}-->
-	<p><a href="$url_forward" class="grey">{lang message_forward_mobile}</a></p>
+	<div><a href="$url_forward" class="grey">{lang message_forward_mobile}</a></div>
 	<!--{elseif $allowreturn}-->
-	<p><a href="javascript:history.back();" class="grey">{lang message_go_back}</a></p>
+	<div><a href="javascript:history.back();" class="grey">{lang message_go_back}</a></div>
 	<!--{/if}-->
 </div>
 <!--{/if}-->


### PR DESCRIPTION
## Summary
- restore LF line endings while keeping upstream showmessage template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850bc924f808328acda1c930d1c7a2f