### PR TITLE
Apply upstream favorite removal check

### DIFF
--- a/source/language/home/lang_template.php
+++ b/source/language/home/lang_template.php
@@ -404,6 +404,7 @@ $lang = array (
   'del_favorite' => '删除选中收藏',
   'collection_favorite' => '添加到淘帖',
   'del_select_favorite_confirm' => '确定要删除选中的收藏吗？',
+  'no_select_favorite' => '请勾选要删除的收藏',
   'favorite_album' => '相册',
   'favorite_all' => '全部收藏',
   'favorite_article' => '文章',

--- a/template/default/home/space_favorite.htm
+++ b/template/default/home/space_favorite.htm
@@ -35,7 +35,7 @@
 				<h1 class="mt">{lang favorite}</h1>
 <!--{/if}-->
 			<!--{if $list}-->
-			<form method="post" autocomplete="off" name="delform" id="delform" action="home.php?mod=spacecp&ac=favorite&op=delete&type=$_GET[type]&checkall=1" onsubmit="showDialog('{lang del_select_favorite_confirm}', 'confirm', '', '$(\'delform\').submit();'); return false;">
+                       <form method="post" autocomplete="off" name="delform" id="delform" action="home.php?mod=spacecp&ac=favorite&op=delete&type=$_GET[type]&checkall=1">
 			<input type="hidden" name="formhash" value="{FORMHASH}" />
 			<input type="hidden" name="delfavorite" value="true" />
 			<ul id="favorite_ul" class="">
@@ -55,7 +55,7 @@
 			</ul>
 			<p class="mtm pns">
 				<label for="chkall" onclick="checkall(this.form, 'favorite')"><input type="checkbox" name="chkall" id="chkall" class="pc vm" />{lang select_all}</label>
-				<button type="submit" name="delsubmit" value="true" class="pn vm"><em>{lang del_favorite}</em></button>
+                               <button type="button" onclick="delall_favorite()" name="delsubmit" value="true" class="pn vm"><em>{lang del_favorite}</em></button>
 				<!--{if $_GET[type] == "thread"}-->
 					<button type="button" name="collectionsubmit" value="true" class="pn pnc vm" onclick="collection_favorite()"><em>{lang collection_favorite}</em></button>
 				<!--{/if}-->
@@ -96,13 +96,31 @@
 </div>
 <!--{/if}-->
 <script type="text/javascript">
-	function favorite_delete(favid) {
-		var el = $('fav_' + favid);
-		if(el) {
-			el.style.display = "none";
-		}
-	}
-	<!--{if $_GET[type] == "thread"}-->
+       function favorite_delete(favid) {
+               var el = $('fav_' + favid);
+               if(el) {
+                       el.style.display = "none";
+               }
+       }
+       function delall_favorite() {
+               var form = $('delform');
+               var prefix = '^favorite';
+               var tids = '';
+               for(var i = 0; i < form.elements.length; i++) {
+                       var e = form.elements[i];
+                       if(e.name.match(prefix) && e.checked) {
+                               tids += 'tids[]=' + e.getAttribute('vid') + '&';
+                       }
+               }
+               if(tids) {
+                       showDialog('{lang del_select_favorite_confirm}', 'confirm', '', '\$(\\'delform\\').submit();');
+               } else {
+                       showDialog('{lang no_select_favorite}');
+                       return false;
+               }
+
+       }
+       <!--{if $_GET[type] == "thread"}-->
 	function collection_favorite() {
 		var form = $('delform');
 		var prefix = '^favorite';


### PR DESCRIPTION
## Summary
- sync discuz favorite deletion fix from upstream
- add missing language string
- ensure the delete button checks selection first

## Testing
- `php -l source/language/home/lang_template.php`
- `php -l template/default/home/space_favorite.htm`


------
https://chatgpt.com/codex/tasks/task_e_6850c322735c8328a9e44069cf591f24