### PR TITLE
Add missing ban status language strings

### DIFF
--- a/source/language/EN/forum/lang_template.php
+++ b/source/language/EN/forum/lang_template.php
@@ -500,6 +500,7 @@ $lang = array (
 	'crime_record'				=> 'Violation log',//'违规记录',
 	'crime_sightml'				=> 'Remove signature',//'清除签名',
 	'crime_warnpost'			=> 'Warn Post',//'警告帖子',
+        'members_ban_none'                      => 'Normal status',//'正常状态',
 	'expiry'				=> 'Expiry',//'期限',
 	'ip_location'				=> 'IP location',//'地理位置',
 	'mod_member_ban'			=> 'Ban user',//'禁止用户',

--- a/source/language/EN/home/lang_template.php
+++ b/source/language/EN/home/lang_template.php
@@ -771,6 +771,7 @@ $lang = array (
 	'crime_record'			=> 'Violation log',//'违规记录',
 	'crime_sightml'			=> 'Remove signature',//'清除签名',
 	'crime_warnpost'		=> 'Warn Post',//'警告帖子',
+        'members_ban_none'              => 'Normal status',//'正常状态',
 	'email_status'			=> 'Email status',//'邮箱状态',
 	'group_useful_life'		=> 'Valid until',//'有效期至',
 	'hours'				=> 'Hours',//'小时',

--- a/source/language/TC/forum/lang_template.php
+++ b/source/language/TC/forum/lang_template.php
@@ -500,6 +500,7 @@ $lang = array (
   'crime_record' => '違規記錄',
   'crime_sightml' => '清除簽名',
   'crime_warnpost' => '警告帖子',
+  'members_ban_none' => '正常狀態',
   'expiry' => '期限',
   'ip_location' => '地理位置',
   'mod_member_ban' => '禁止用戶',

--- a/source/language/TC/home/lang_template.php
+++ b/source/language/TC/home/lang_template.php
@@ -774,6 +774,7 @@ $lang = array (
   'crime_record' => '違規記錄',
   'crime_sightml' => '清除簽名',
   'crime_warnpost' => '警告帖子',
+  'members_ban_none' => '正常狀態',
   'email_status' => '郵箱狀態',
   'group_useful_life' => '有效期至',
   'hours' => '小時',


### PR DESCRIPTION
## Summary
- add `members_ban_none` text in EN and TC translations for home and forum

## Testing
- `php -l source/language/EN/home/lang_template.php`
- `php -l source/language/EN/forum/lang_template.php`
- `php -l source/language/TC/home/lang_template.php`
- `php -l source/language/TC/forum/lang_template.php`


------
https://chatgpt.com/codex/tasks/task_e_6850d8533b048328b249bd526212590d