### PR TITLE
Sync forum_post localization

### DIFF
--- a/static/js/forum_post.js
+++ b/static/js/forum_post.js
@@ -16,21 +16,21 @@ var UPLOADWINRECALL = null;
 var imgexts = typeof imgexts == 'undefined' ? 'jpg, jpeg, gif, png, bmp' : imgexts;
 var ATTACHORIMAGE = '0';
 var STATUSMSG = {
-	'-1' : '内部服务器错误',
-	'0' : '上传成功',
-	'1' : '不支持此类扩展名',
-	'2' : '服务器限制无法上传那么大的附件',
-	'3' : '用户组限制无法上传那么大的附件',
-	'4' : '不支持此类扩展名',
-	'5' : '文件类型限制无法上传那么大的附件',
-	'6' : '今日您已无法上传更多的附件',
-	'7' : '请选择图片文件(' + imgexts + ')',
-	'8' : '附件文件无法保存',
-	'9' : '没有合法的文件被上传',
-	'10' : '非法操作',
-	'11' : '今日您已无法上传那么大的附件',
-	'12' : '因文件名包含敏感词而无法提交',
-	'13' : '服务器限制无法上传分辨率过高的附件'
+        /*vot*/ '-1' : lng['internal_error'],
+        /*vot*/ '0' :  lng['upload_ok'],
+        /*vot*/ '1' :  lng['ext_not_supported'],
+        /*vot*/ '2' :  lng['attach_big'],
+        /*vot*/ '3' :  lng['attach_group_big'],
+        /*vot*/ '4' :  lng['ext_not_supported'],
+        /*vot*/ '5' :  lng['attach_type_big'],
+        /*vot*/ '6' :  lng['attach_daily_big'],
+        /*vot*/ '7' :  lng['select_image_files']+' (' + imgexts + ')',
+        /*vot*/ '8' :  lng['can_not_save_attach'],
+        /*vot*/ '9' :  lng['invalid_file'],
+        /*vot*/ '10' : lng['illegal_operation'],
+        /*vot*/ '11' : lng['today_upload_large'],
+        /*vot*/ '12' : lng['bad_words'],
+        /*vot*/ '13' : lng['high_resolution']
 };
 
 EXTRAFUNC['validator'] = [];
@@ -62,7 +62,7 @@ function checklength(theform) {
 	if(!theform.parseurloff.checked) {
 		message = parseurl(message);
 	}
-	showDialog('当前长度: ' + mb_strlen(message) + ' 字节，' + (postmaxchars != 0 ? '系统限制: ' + postminchars + ' 到 ' + postmaxchars + ' 字节。' : ''), 'notice', '字数检查');
+        /*vot*/ showDialog(lng['current_length']+': ' + mb_strlen(message) + ' '+lng['bytes']+', ' + (postmaxchars != 0 ? lng['system_limit']+': ' + postminchars + ' '+lng['up_to']+' ' + postmaxchars + ' '+lng['bytes']+'.' : ''), 'notice', lng['check_length']);
 }
 
 if(!tradepost) {
@@ -74,24 +74,24 @@ function validate(theform) {
 	if(!theform.parseurloff.checked) {
 		message = parseurl(message);
 	}
-	if(($('postsubmit').name != 'replysubmit' && !($('postsubmit').name == 'editsubmit' && !isfirstpost) && theform.subject.value == "") || !sortid && !special && trim(message) == "") {
-		showError('抱歉，您尚未输入标题或内容');
+        if(($('postsubmit').name != 'replysubmit' && !($('postsubmit').name == 'editsubmit' && !isfirstpost) && theform.subject.value == "") || !sortid && !special && trim(message) == "") {
+                /*vot*/         showError(lng['enter_content']);
 		return false;
-	} else if(dstrlen(theform.subject.value) > 255) {
-		showError('您的标题超过 255 个字符的限制');
+        } else if(dstrlen(theform.subject.value) > 255) {
+                /*vot*/         showError(lng['title_long']);
 		return false;
 	}
-	if(!disablepostctrl && theform.subject.value != "" && ((postminsubjectchars != 0 && dstrlen(theform.subject.value) < postminsubjectchars) || (postminsubjectchars != 0 && dstrlen(theform.subject.value) > postmaxsubjectchars))) {
-		showError('您的标题长度不符合要求。\n\n当前长度: ' + dstrlen(theform.subject.value) + ' 字\n系统限制: ' + postminsubjectchars + ' 到 ' + postmaxsubjectchars + ' 字');
+        if(!disablepostctrl && theform.subject.value != "" && ((postminsubjectchars != 0 && dstrlen(theform.subject.value) < postminsubjectchars) || (postminsubjectchars != 0 && dstrlen(theform.subject.value) > postmaxsubjectchars))) {
+                /*vot*/         showError(lng['content_long'] + dstrlen(theform.subject.value) + lng['characters'] + '\n' + lng['system_limit'] + postminsubjectchars + lng['up_to'] + postmaxsubjectchars + lng['characters']);
 		return false;
 	}
 	if(in_array($('postsubmit').name, ['topicsubmit', 'editsubmit'])) {
-		if(theform.typeid && (theform.typeid.options && theform.typeid.options[theform.typeid.selectedIndex].value == 0) && typerequired) {
-			showError('请选择主题对应的分类');
+                if(theform.typeid && (theform.typeid.options && theform.typeid.options[theform.typeid.selectedIndex].value == 0) && typerequired) {
+                        /*vot*/                 showError(lng['select_category']);
 			return false;
 		}
-		if(theform.sortid && (theform.sortid.options && theform.sortid.options[theform.sortid.selectedIndex].value == 0) && sortrequired) {
-			showError('请选择主题对应的分类信息');
+                if(theform.sortid && (theform.sortid.options && theform.sortid.options[theform.sortid.selectedIndex].value == 0) && sortrequired) {
+                        /*vot*/                 showError(lng['select_category_info']);
 			return false;
 		}
 	}
@@ -104,21 +104,21 @@ function validate(theform) {
 		} catch(e) {}
 	}
 
-	if(!disablepostctrl && !sortid && !special && ((postminchars != 0 && mb_strlen(message) < postminchars) || (postmaxchars != 0 && mb_strlen(message) > postmaxchars))) {
-		showError('您的帖子长度不符合要求。\n\n当前长度: ' + mb_strlen(message) + ' 字节\n系统限制: ' + postminchars + ' 到 ' + postmaxchars + ' 字节');
+        if(!disablepostctrl && !sortid && !special && ((postminchars != 0 && mb_strlen(message) < postminchars) || (postmaxchars != 0 && mb_strlen(message) > postmaxchars))) {
+                /*vot*/         showError(lng['content_long'] + lng['current_length']+': ' + mb_strlen(message) + ' '+lng['bytes']+'\n'+lng['system_limit']+': ' + postminchars + ' '+lng['up_to']+' ' + postmaxchars + ' '+lng['bytes']);
 		return false;
 	}
-	if(UPLOADSTATUS == 0) {
-		if(!confirm('您有等待上传的附件，确认不上传这些附件吗？')) {
+        if(UPLOADSTATUS == 0) {
+                /*vot*/         if(!confirm(lng['ignore_pending_attach'])) {
 			return false;
 		}
-	} else if(UPLOADSTATUS == 1) {
-		showDialog('您有正在上传的附件，请稍候，上传完成后帖子将会自动发表...', 'notice');
+        } else if(UPLOADSTATUS == 1) {
+                /*vot*/         showDialog(lng['still_uploading'], 'notice');
 		AUTOPOST = 1;
 		return false;
 	}
-	if(isfirstpost && $('adddynamic') != null && $('adddynamic').checked && $('postsave') != null && isNaN(parseInt($('postsave').value)) && ($('readperm') != null && $('readperm').value || $('price') != null && $('price').value)) {
-		if(confirm('由于您设置了阅读权限或出售帖，您确认还转播给您的听众看吗？') == false) {
+        if(isfirstpost && $('adddynamic') != null && $('adddynamic').checked && $('postsave') != null && isNaN(parseInt($('postsave').value)) && ($('readperm') != null && $('readperm').value || $('price') != null && $('price').value)) {
+                /*vot*/         if(confirm(lng['feed_add_confirm']) == false) {
 			return false;
 		}
 	}
@@ -138,8 +138,8 @@ function validate(theform) {
 					if($('secqaaverify_' + theform.secqaahash.value) == document.activeElement) {
 						$('postsubmit').focus();
 						setTimeout(function () { validate(theform); }, 100);
-					} else {
-						showError('验证问答错误，请重新填写');
+                                        } else {
+/*vot*/                                         showError(lng['q&a_invalid']);
 					}
 					chk = 0;
 				}
@@ -153,8 +153,8 @@ function validate(theform) {
 					if($('seccodeverify_' + theform.seccodehash.value) == document.activeElement) {
 						$('postsubmit').focus();
 						setTimeout(function () { validate(theform); }, 100);
-					} else {
-						showError('验证码错误，请重新填写');
+                                        } else {
+/*vot*/                                         showError(lng['code_invalid']);
 					}
 					chk = 0;
 				}
@@ -224,12 +224,12 @@ function uploadNextAttach() {
 	var arr = str.split('|');
 	var att = CURRENTATTACH.split('|');
 	var sizelimit = '';
-	if(arr[4] == 'ban') {
-		sizelimit = '(附件类型被禁止)';
-	} else if(arr[4] == 'perday') {
-		sizelimit = '(不能超过 ' + arr[5] + ' 字节)';
-	} else if(arr[4] > 0) {
-		sizelimit = '(不能超过 ' + arr[4] + ' 字节)';
+        if(arr[4] == 'ban') {
+/*vot*/         sizelimit = '('+lng['attach_type_disabled']+')';
+        } else if(arr[4] == 'perday') {
+/*vot*/         sizelimit = '('+lng['attach_max'] + ' ' + arr[5] + ' ' + lng['bytes'] + ')';
+        } else if(arr[4] > 0) {
+/*vot*/         sizelimit = '('+lng['attach_max'] + ' ' + arr[4] + ' ' + lng['bytes'] + ')';
 	}
 	uploadAttach(parseInt(att[0]), arr[0] == 'DISCUZUPLOAD' ? parseInt(arr[1]) : -1, att[1], sizelimit);
 }
@@ -267,23 +267,23 @@ function uploadAttach(curId, statusid, prefix, sizelimit) {
 			} else {
 				updateAttachList();
 			}
-			if(UPLOADFAILED > 0) {
-				showDialog('附件上传完成！成功 ' + UPLOADCOMPLETE + ' 个，失败 ' + UPLOADFAILED + ' 个:' + FAILEDATTACHS);
+                        if(UPLOADFAILED > 0) {
+/*vot*/                         showDialog(lng['upload_finished']+' '+lng['successfull']+' ' + UPLOADCOMPLETE + ', '+lng['failed']+' ' + UPLOADFAILED + ', '+lng['ones']+': ' + FAILEDATTACHS);
 				FAILEDATTACHS = '';
 			}
 			UPLOADSTATUS = 2;
 			for(var i = 0; i < AID[prefix ? 1 : 0] - 1; i++) {
-				if($(prefix + 'attachform_' + i)) {
-					reAddAttach(prefix, i)
-				}
+                                if($(prefix + 'attachform_' + i)) {
+                                        reAddAttach(prefix, i);
+                                }
 			}
 			$(prefix + 'uploadbtn').style.display = '';
 			$(prefix + 'uploading').style.display = 'none';
 			if(AUTOPOST) {
 				hideMenu();
 				validate($('postform'));
-			} else if(UPLOADFAILED == 0 && (prefix == 'img' || prefix == '')) {
-				showDialog('附件上传完成！', 'right', null, null, 0, null, null, null, null, 3);
+                        } else if(UPLOADFAILED == 0 && (prefix == 'img' || prefix == '')) {
+/*vot*/                         showDialog(lng['upload_finished'], 'right', null, null, 0, null, null, null, null, 3);
 			}
 			UPLOADFAILED = UPLOADCOMPLETE = 0;
 			CURRENTATTACH = '0';
@@ -294,7 +294,7 @@ function uploadAttach(curId, statusid, prefix, sizelimit) {
 		$(prefix + 'uploadbtn').style.display = 'none';
 		$(prefix + 'uploading').style.display = '';
 	}
-	$(prefix + 'cpdel_' + nextId).innerHTML = '<div class="loadicon" title="上传中..."></div>';
+/*vot*/ $(prefix + 'cpdel_' + nextId).innerHTML = '<div class="loadicon" title="'+lng['uploading']+'"></div>';
 	UPLOADSTATUS = 1;
 	$(prefix + 'attachform_' + nextId).submit();
 }
@@ -352,18 +352,18 @@ function insertAttach(prefix, id) {
 	if(path == '') {
 		return;
 	}
-	if(extensions != '' && (re.exec(extensions) == null || ext == '')) {
-		reAddAttach(prefix, id);
-		showError('对不起，不支持上传此类扩展名的附件。');
-		return;
-	}
-	if(prefix == 'img' && imgexts.indexOf(ext) == -1) {
-		reAddAttach(prefix, id);
-		showError('请选择图片文件(' + imgexts + ')');
-		return;
-	}
+        if(extensions != '' && (re.exec(extensions) == null || ext == '')) {
+                reAddAttach(prefix, id);
+/*vot*/         showError(lng['sorry_ext_not_supported']);
+                return;
+        }
+        if(prefix == 'img' && imgexts.indexOf(ext) == -1) {
+                reAddAttach(prefix, id);
+/*vot*/         showError(lng['select_image_files']+' (' + imgexts + ')');
+                return;
+        }
 
-	$(prefix + 'cpdel_' + id).innerHTML = '<a href="javascript:;" class="d" onclick="reAddAttach(\'' + prefix + '\', ' + id + ')">删除</a>';
+/*vot*/ $(prefix + 'cpdel_' + id).innerHTML = '<a href="javascript:;" class="d" onclick="reAddAttach(\'' + prefix + '\', ' + id + ')">'+lng['delete']+'</a>';
 	$(prefix + 'localfile_' + id).innerHTML = '<span>' + filename + '</span>';
 	$(prefix + 'attachnew_' + id).style.display = 'none';
 	$(prefix + 'deschidden_' + id).style.display = '';
@@ -431,9 +431,9 @@ function appendAttachDel(ids) {
 		if($('delattachop')) {
 			$('delattachop').value = 1;
 		}
-	} else {
-		showError('抱歉，删除操作失败，请刷新页面后重试。');
-	}
+        } else {
+/*vot*/                 showError(lng['delete_post_failed']);
+        }
 }
 
 function updateAttach(aid) {
@@ -441,7 +441,7 @@ function updateAttach(aid) {
 	obj = $('attach' + aid);
 	if(!objupdate.innerHTML) {
 		obj.style.display = 'none';
-		objupdate.innerHTML = '<input type="file" name="attachupdate[paid' + aid + ']"><a href="javascript:;" onclick="updateAttach(' + aid + ')">取消</a>';
+/*vot*/         objupdate.innerHTML = '<input type="file" name="attachupdate[paid' + aid + ']"><a href="javascript:;" onclick="updateAttach(' + aid + ')">'+lng['cancel']+'</a>';
 	} else {
 		obj.style.display = '';
 		objupdate.innerHTML = '';
@@ -453,16 +453,16 @@ function updateattachnum(type) {
 	ATTACHNUM[type + 'unused'] = ATTACHNUM[type + 'unused'] >= 0 ? ATTACHNUM[type + 'unused'] : 0;
 	var num = ATTACHNUM[type + 'used'] + ATTACHNUM[type + 'unused'];
 	if(num) {
-		if($(editorid + '_' + type)) {
-			$(editorid + '_' + type).title = '包含 ' + num + (type == 'image' ? ' 个图片附件' : ' 个附件');
-		}
+                if($(editorid + '_' + type)) {
+/*vot*/                     $(editorid + '_' + type).title = lng['contains']+' ' + num + (type == 'image' ? ' '+lng['img_attached_num'] : ' '+lng['files attached_num']);
+                }
 		if($(editorid + '_' + type + 'n')) {
 			$(editorid + '_' + type + 'n').style.display = '';
 		}
 		ATTACHORIMAGE = 1;
 	} else {
-		if($(editorid + '_' + type)) {
-			$(editorid + '_' + type).title = type == 'image' ? '图片' : '附件';
+                if($(editorid + '_' + type)) {
+/*vot*/                     $(editorid + '_' + type).title = type == 'image' ? lng['images'] : lng['attachments'];
 		}
 		if($(editorid + '_' + type + 'n')) {
 			$(editorid + '_' + type + 'n').style.display = 'none';
@@ -492,12 +492,12 @@ function updateImageList(action, aids) {
 
 function updateDownImageList(msg) {
 	hideMenu('fwin_dialog', 'dialog');
-	if(msg == '') {
-		showError('抱歉，暂无远程附件');
+        if(msg == '') {
+/*vot*/             showError(lng['no_remote_attach']);
 	} else {
 		ajaxget('forum.php?mod=ajax&action=imagelist&pid=' + pid + '&posttime=' + $('posttime').value + (!fid ? '' : '&fid=' + fid), 'imgattachlist', null, null, null, function(){if(wysiwyg) {editdoc.body.innerHTML = msg;switchEditor(0);switchEditor(1)} else {textobj.value = msg;}});
 		switchImagebutton('imgattachlist');$('imgattach_notice').style.display = '';
-		showDialog('远程附件下载完成!', 'right', null, null, 0, null, null, null, null, 3);
+/*vot*/             showDialog(lng['remote_attach_loaded'], 'right', null, null, 0, null, null, null, null, 3);
 	}
 }
 
@@ -539,12 +539,12 @@ function uploadWindowload() {
 		hideWindow('upload', 0);
 	} else {
 		var sizelimit = '';
-		if(arr[7] == 'ban') {
-			sizelimit = '(附件类型被禁止)';
-		} else if(arr[7] == 'perday') {
-			sizelimit = '(不能超过 ' + arr[8] + ' 字节)';
-		} else if(arr[7] > 0) {
-			sizelimit = '(不能超过 ' + arr[7] + ' 字节)';
+                if(arr[7] == 'ban') {
+/*vot*/                     sizelimit = '('+lng['attach_type_disabled']+')';
+                } else if(arr[7] == 'perday') {
+/*vot*/                     sizelimit = '('+lng['attach_max']+' ' + arr[8] + ' '+lng['bytes']+')';
+                } else if(arr[7] > 0) {
+/*vot*/                     sizelimit = '('+lng['attach_max']+' ' + arr[7] + ' '+lng['bytes']+')';
 		}
 		showError(STATUSMSG[arr[2]] + sizelimit);
 	}
@@ -637,11 +637,11 @@ function addpolloption() {
 		$('polloption_new').outerHTML = '<p>' + pollstr + '</p>' + $('polloption_new').outerHTML;
 		curoptions++;
 		curnumber++;
-		addUploadEvent(imgid, proid)
+                addUploadEvent(imgid, proid);
 
-	} else {
-		$('polloption_new').innerHTML = '已达到最大投票数' + maxoptions;
-	}
+        } else {
+/*vot*/             $('polloption_new').innerHTML = '<span>'+lng['vote_max_reached']+maxoptions+'</span>';
+        }
 }
 
 function delpolloption(obj) {
@@ -706,9 +706,9 @@ function attachoption(type, op) {
 		}
 		display('attachnotice_' + type);
 	} else if(op == 2) {
-		showDialog('<div id="unusedwin" class="c altw" style="overflow:auto;height:100px;">' + $('unusedlist_' + type).innerHTML + '</div>' +
-			'<p class="o pns"><span class="z xg1"><label for="unusedwinchkall"><input id="unusedwinchkall" type="checkbox" onclick="attachoption(\'' + type + '\', 3)" checked="checked" />全选</label></span>' +
-			'<button onclick="attachoption(\'' + type + '\', 1);hideMenu(\'fwin_dialog\', \'dialog\')" class="pn pnc"><strong>使用</strong></button></p>', 'info', '未使用的' + (type == 'attach' ? '附件' : '图片'));
+                showDialog('<div id="unusedwin" class="c altw" style="overflow:auto;height:100px;">' + $('unusedlist_' + type).innerHTML + '</div>' +
+/*vot*/                 '<p class="o pns"><span class="z xg1"><label for="unusedwinchkall"><input id="unusedwinchkall" type="checkbox" onclick="attachoption(\'' + type + '\', 3)" checked="checked" />'+lng['select_all']+'</label></span>' +
+/*vot*/                 '<button onclick="attachoption(\'' + type + '\', 1);hideMenu(\'fwin_dialog\', \'dialog\')" class="pn pnc"><strong>'+lng['ok']+'</strong></button></p>', 'info', lng['unused']+' ' + (type == 'attach' ? lng['attachment'] : lng['image']));
 	} else if(op == 3) {
 		list = $('unusedwin').getElementsByTagName('INPUT');
 		for(i = 0;i < list.length;i++) {
@@ -838,11 +838,11 @@ function getreplycredit() {
 	var reply_credits_sum = Math.ceil(parseInt(credit_once * times));
 
 	$('replycredit_sum').innerHTML = reply_credits_sum > 0 ? reply_credits_sum : 0 ;
-	if(real_reply_credit > userextcredit) {
-		$('replycredit').innerHTML = '<b class="xi1">回帖奖励积分总额过大('+real_reply_credit+')</b>';
-	} else {
-		if(have_replycredit > 0 && real_reply_credit < 0) {
-			$('replycredit').innerHTML = "<font class='xi1'>返还"+Math.abs(real_reply_credit)+"</font>";
+        if(real_reply_credit > userextcredit) {
+/*vot*/             $('replycredit').innerHTML = '<b class="xi1">'+lng['award_more_total']+' ('+real_reply_credit+')</b>';
+        } else {
+                if(have_replycredit > 0 && real_reply_credit < 0) {
+/*vot*/                     $('replycredit').innerHTML = "<font class='xi1'>"+lng['return']+" "+Math.abs(real_reply_credit)+"</font>";
 		} else {
 			$('replycredit').innerHTML = replycredit_result_lang + (real_reply_credit > 0 ? real_reply_credit : 0 );
 		}
@@ -856,7 +856,7 @@ function extraCheckall() {
 }
 
 function deleteThread() {
-	if(confirm('确定要删除该帖子吗？') != 0){
+/*vot*/ if(confirm(lng['delete_post_sure']) != 0){
 		$('delete').value = '1';
 		onbeforeunload=null;
 		$('postform').submit();


### PR DESCRIPTION
## Summary
- sync `static/js/forum_post.js` with upstream localization strings
- use language keys instead of hardcoded messages
- address a couple of missing semicolons

## Testing
- `npx -y jshint static/js/forum_post.js` *(fails: 107 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851efc031f483289528c3e476977a8d