### PR TITLE
Fix translation key typo

### DIFF
--- a/source/language/EN/lang_js.js
+++ b/source/language/EN/lang_js.js
@@ -436,7 +436,7 @@ var lng = {
 
 	'select_max'		: 'You can select up to',//'最多只允许选择',
 	'users'			: 'users',//'个用户',
-	'allready_exists'       : 'Already exists',
+       'already_exists'        : 'Already exists',
 
 //--------------------------------
 //static/js/home_manage.js

--- a/source/language/lang_js.js
+++ b/source/language/lang_js.js
@@ -443,7 +443,7 @@ var lng = {
 
 	'select_max'		: '最多只允许选择',
 	'users'			: '个用户',
-	'allready_exists'	: '已经存在',
+	'already_exists'	: '已经存在',
 
 //--------------------------------
 //static/js/home_manage.js

--- a/static/js/home_friendselector.js
+++ b/static/js/home_friendselector.js
@@ -174,7 +174,7 @@
 					this.handleObj.parentNode.insertBefore(spanObj, this.handleObj);
 					this.showObj.style.display = 'none';
 				} else {
-					alert(lng['allready_exists']+':'+userName);
+					alert(lng['already_exists']+':'+userName);
 				}
 			}
 		},


### PR DESCRIPTION
## Summary
- correct the typo `allready_exists` -> `already_exists`
- update JS translation keys accordingly

## Testing
- `grep -R "already_exists" -n`

------
https://chatgpt.com/codex/tasks/task_e_685221d4e8348328934c91d81465b451