### PR TITLE
Fix tag suggestion handlers after DOM loads

### DIFF
--- a/static/js/forum_viewthread.js
+++ b/static/js/forum_viewthread.js
@@ -806,42 +806,44 @@ function bumpthread() {
                 });
 }
 
-if($('suggestTagsButton')) {
-    $('suggestTagsButton').onclick = function() {
-        this.style.display = 'none';
-        $('suggestTagsInputArea').style.display = '';
-    };
-}
-if($('cancelSuggestTags')) {
-    $('cancelSuggestTags').onclick = function() {
-        $('suggestTagsInputArea').style.display = 'none';
-        if($('suggestTagsButton')) $('suggestTagsButton').style.display = '';
-        $('suggestedTagInput').value = '';
-        $('suggestionMessage').style.display = 'none';
-    };
-}
-if($('submitSuggestedTag')) {
-    $('submitSuggestedTag').onclick = function() {
-        var tag = trim($('suggestedTagInput').value);
-        if(!tag) return false;
-        var tid = $('sug_tid') ? $('sug_tid').value : (typeof window.tid != 'undefined' ? window.tid : 0);
-        fetch('forum.php?mod=tag&op=suggest&inajax=1', {
-            method: 'POST',
-            headers: {'Content-Type':'application/x-www-form-urlencoded'},
-            body: 'formhash='+FORMHASH+'&tid='+tid+'&tag='+encodeURIComponent(tag)
-        }).then(res => res.json()).then(d => {
-            if(d.success) {
-                $('suggestTagsInputArea').style.display = 'none';
-                $('suggestionMessage').style.display = '';
-                if($('suggestTagsButton')) $('suggestTagsButton').style.display = '';
-                $('suggestedTagInput').value = '';
-                setTimeout(function(){ $('suggestionMessage').style.display = 'none'; },3000);
-            } else if(d.message) {
-                showError(d.message);
-            }
-        }).catch(function(error){
-            console.error('Error suggesting tag:', error);
-            showError(lng['network_error'] || 'A network error occurred. Please try again.');
-        });
-    };
-}
+document.addEventListener('DOMContentLoaded', function() {
+    if($('suggestTagsButton')) {
+        $('suggestTagsButton').onclick = function() {
+            this.style.display = 'none';
+            $('suggestTagsInputArea').style.display = '';
+        };
+    }
+    if($('cancelSuggestTags')) {
+        $('cancelSuggestTags').onclick = function() {
+            $('suggestTagsInputArea').style.display = 'none';
+            if($('suggestTagsButton')) $('suggestTagsButton').style.display = '';
+            $('suggestedTagInput').value = '';
+            $('suggestionMessage').style.display = 'none';
+        };
+    }
+    if($('submitSuggestedTag')) {
+        $('submitSuggestedTag').onclick = function() {
+            var tag = trim($('suggestedTagInput').value);
+            if(!tag) return false;
+            var tid = $('sug_tid') ? $('sug_tid').value : (typeof window.tid != 'undefined' ? window.tid : 0);
+            fetch('forum.php?mod=tag&op=suggest&inajax=1', {
+                method: 'POST',
+                headers: {'Content-Type':'application/x-www-form-urlencoded'},
+                body: 'formhash='+FORMHASH+'&tid='+tid+'&tag='+encodeURIComponent(tag)
+            }).then(res => res.json()).then(d => {
+                if(d.success) {
+                    $('suggestTagsInputArea').style.display = 'none';
+                    $('suggestionMessage').style.display = '';
+                    if($('suggestTagsButton')) $('suggestTagsButton').style.display = '';
+                    $('suggestedTagInput').value = '';
+                    setTimeout(function(){ $('suggestionMessage').style.display = 'none'; },3000);
+                } else if(d.message) {
+                    showError(d.message);
+                }
+            }).catch(function(error){
+                console.error('Error suggesting tag:', error);
+                showError(lng['network_error'] || 'A network error occurred. Please try again.');
+            });
+        };
+    }
+});


### PR DESCRIPTION
## Summary
- ensure forum_viewthread.js waits for DOMContentLoaded before attaching tag suggestion event handlers

## Testing
- `php -l tests/check_discuz_login.php`

------
https://chatgpt.com/codex/tasks/task_e_685251602b8083288d4a869b4c719fc8