### PR TITLE
Fix tag suggestion DB insert method

### DIFF
--- a/source/class/table/table_forum_tag_suggest.php
+++ b/source/class/table/table_forum_tag_suggest.php
@@ -11,8 +11,8 @@ class table_forum_tag_suggest extends discuz_table {
         parent::__construct();
     }
 
-    public function insert($data) {
-        return DB::insert($this->_table, $data, true);
+    public function insert($data, $return_insert_id = false, $replace = false, $silent = false) {
+        return DB::insert($this->_table, $data, $return_insert_id, $replace, $silent);
     }
 
     public function fetch_all_by_status($status, $start = 0, $limit = 0, $count = false) {


### PR DESCRIPTION
## Summary
- align `table_forum_tag_suggest::insert` method signature with parent class

## Testing
- `curl -i -b <cookie> http://127.0.0.1:8000/forum.php?mod=tag&op=suggest&inajax=1 --data 'formhash=47335e69&tid=13981&tag=%E5%8D%8A%E5%BE%84'`

------
https://chatgpt.com/codex/tasks/task_e_6852787fea388328b0a6744212473720