### PR TITLE
Improve tag suggestion prompt

### DIFF
--- a/source/language/EN/forum/lang_template.php
+++ b/source/language/EN/forum/lang_template.php
@@ -682,7 +682,6 @@ $lang = array (
 	'recent_use_tag'		=> 'Recently used tags:',//'最近使用标签:',
         'suggest_tags'                  => 'Suggest Tags' ,
         'suggest_tags_label'            => 'Suggest keyword to make this page easier to find:' ,
-        'thanks_for_suggestion'         => 'We appreciate your suggestion. Thank you!' ,
 	'replycredit_empty'		=> '(leave blank or fill 0 for no reward)',//'(留空或填 0 为不奖励)',
 	'replycredit_however'		=> 'Still have replies',//'本帖尚有',
 	'replycredit_member'		=> 'up to a maximum per person',//'每人最多可获得',

--- a/source/language/EN/lang_js.js
+++ b/source/language/EN/lang_js.js
@@ -392,6 +392,7 @@ var lng = {
 	'qq_bind'		: 'Please bind your QQ account',//'请先绑定QQ账号',
 	'quote_by'		: 'Quote by .*? in .*? code',//'本帖最后由 .*? 于 .*? 编辑',
 	'copy_code'		: 'Copy code',//'复制代码',
+        'thanks_for_suggestion' : 'We appreciate your suggestion. Thank you!',
 	'download_pocket_forum'	: 'Download Pocket Forum',//'下载掌上论坛',
 	'pocket_forum_android'	: 'If Andriod version, Scan thw QR-code can be downloaded directly to the phone',//'Andriod版本，扫描二维码可以直接下载到手机',
 	'pocket_forum_android_alt'	: 'Suitable for Android-based smartphones like Samsung/HTC/etc',//'适用于装有安卓系统的三星/HTC/小米等手机',

--- a/source/language/TC/forum/lang_template.php
+++ b/source/language/TC/forum/lang_template.php
@@ -683,7 +683,6 @@ $lang = array (
   'recent_use_tag' => '最近使用標籤:',
   'suggest_tags' => '建議標籤',
   'suggest_tags_label' => '建議關鍵字讓此頁更容易被找到:',
-  'thanks_for_suggestion' => '感謝您的建議！',
   'replycredit_empty' => '(留空或填 0 為不獎勵)',
   'replycredit_however' => '本帖尚有',
   'replycredit_member' => '每人最多可獲得',

--- a/source/language/forum/lang_template.php
+++ b/source/language/forum/lang_template.php
@@ -683,7 +683,6 @@ $lang = array (
   'recent_use_tag' => '最近使用标签:',
   'suggest_tags' => '建议标签',
   'suggest_tags_label' => '建议关键词以便更容易找到本页:',
-  'thanks_for_suggestion' => '感谢您的建议！',
   'replycredit_empty' => '(留空或填 0 为不奖励)',
   'replycredit_however' => '本帖尚有',
   'replycredit_member' => '每人最多可获得',

--- a/source/language/lang_js.js
+++ b/source/language/lang_js.js
@@ -398,6 +398,7 @@ var lng = {
 	'qq_bind'		: '请先绑定QQ账号',
 	'quote_by'		: '本帖最后由 .*? 于 .*? 编辑',
 	'copy_code'		: '复制代码',
+        'thanks_for_suggestion' : '感谢您的建议！',
 	'download_pocket_forum'	: '下载掌上论坛',//'Download Pocket Forum',
 	'pocket_forum_android'	: 'Andriod版本，扫描二维码可以直接下载到手机',//'If Andriod version, Scan thw QR-code can be downloaded directly to the phone',
 	'pocket_forum_android_alt'	: '适用于装有安卓系统的三星/HTC/小米等手机',//'Suitable for Android-based smartphones like Samsung/HTC/etc',

--- a/static/js/forum_viewthread.js
+++ b/static/js/forum_viewthread.js
@@ -811,7 +811,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const suggestTagsInputArea = $('suggestTagsInputArea');
     const cancelSuggestTagsButton = $('cancelSuggestTags');
     const suggestedTagInput = $('suggestedTagInput');
-    const suggestionMessage = $('suggestionMessage');
     const submitSuggestedTagButton = $('submitSuggestedTag');
     const sugTidElement = $('sug_tid');
 
@@ -826,7 +825,6 @@ document.addEventListener('DOMContentLoaded', function() {
             if(suggestTagsInputArea) suggestTagsInputArea.style.display = 'none';
             if(suggestTagsButton) suggestTagsButton.style.display = '';
             if(suggestedTagInput) suggestedTagInput.value = '';
-            if(suggestionMessage) suggestionMessage.style.display = 'none';
         };
     }
     if(submitSuggestedTagButton) {
@@ -842,10 +840,9 @@ document.addEventListener('DOMContentLoaded', function() {
             }).then(res => res.json()).then(d => {
                 if(d.success) {
                     if(suggestTagsInputArea) suggestTagsInputArea.style.display = 'none';
-                    if(suggestionMessage) suggestionMessage.style.display = '';
                     if(suggestTagsButton) suggestTagsButton.style.display = '';
                     if(suggestedTagInput) suggestedTagInput.value = '';
-                    setTimeout(function(){ if(suggestionMessage) suggestionMessage.style.display = 'none'; },3000);
+                    showPrompt(null, null, '<span>' + lng['thanks_for_suggestion'] + '</span>', 1500);
                 } else if(d.message) {
                     showError(d.message);
                 }

--- a/template/default/forum/viewthread.htm
+++ b/template/default/forum/viewthread.htm
@@ -361,7 +361,6 @@ $_G['forum_tagscript']
         <input type="text" id="suggestedTagInput" class="px vm">
         <button id="submitSuggestedTag" class="pn pnc"><span>{lang submit}</span></button>
         <button id="cancelSuggestTags" class="pn"><span>{lang cancel}</span></button>
-        <div id="suggestionMessage" class="mtm" style="display:none">{lang thanks_for_suggestion}</div>
     </div>
 </div>
 

--- a/template/default/touch/forum/viewthread.htm
+++ b/template/default/touch/forum/viewthread.htm
@@ -433,7 +433,6 @@
         <input type="text" id="suggestedTagInput" class="px vm" />
         <button id="submitSuggestedTag" class="button">{lang submit}</button>
         <button id="cancelSuggestTags" class="button">{lang cancel}</button>
-        <div id="suggestionMessage" style="display:none">{lang thanks_for_suggestion}</div>
     </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- show tag suggestion feedback with `showPrompt` instead of toggling a hidden div
- remove unused suggestion message markup from templates
- add JavaScript translations for `thanks_for_suggestion`
- remove obsolete `thanks_for_suggestion` strings from PHP language files

------
https://chatgpt.com/codex/tasks/task_e_685298eb0d008328a8af03bd0888d283