### PR TITLE
Fix JS lang cache busting

### DIFF
--- a/source/function/function_admincp.php
+++ b/source/function/function_admincp.php
@@ -351,7 +351,7 @@ function cpheader() {
 <script type="text/JavaScript">
 var admincpfilename = '$basescript', IMGDIR = '$IMGDIR', STYLEID = '$STYLEID', VERHASH = '$VERHASH', IN_ADMINCP = true, ISFRAME = $frame, STATICURL='static/', SITEURL = '{$_G['siteurl']}', JSPATH = '{$_G['setting']['jspath']}';
 </script>
-<script src="/source/language/lang_js.js"></script>
+<script src="/source/language/lang_js.js?{VERHASH}"></script>
 <script src="{$_G['setting']['jspath']}common.js?{$_G['style']['verhash']}" type="text/javascript"></script>
 <script src="{$_G['setting']['jspath']}admincp.js?{$_G['style']['verhash']}" type="text/javascript"></script>
 <script type="text/javascript">

--- a/template/default/common/header_common.htm
+++ b/template/default/common/header_common.htm
@@ -69,9 +69,9 @@ local('Songti TC');   /* 宋体 TC, macOS Traditional Chinese */
 	<!--{csstemplate}-->
 	<script type="text/javascript">var STYLEID = '{STYLEID}', STATICURL = '{STATICURL}', IMGDIR = '{IMGDIR}', VERHASH = '{VERHASH}', charset = '{CHARSET}', discuz_uid = '$_G[uid]', cookiepre = '{$_G[config][cookie][cookiepre]}', cookiedomain = '{$_G[config][cookie][cookiedomain]}', cookiepath = '{$_G[config][cookie][cookiepath]}', showusercard = '{$_G[setting][showusercard]}', attackevasive = '{$_G[config][security][attackevasive]}', disallowfloat = '{$_G[setting][disallowfloat]}', creditnotice = '<!--{if $_G['setting']['creditnotice']}-->$_G['setting']['creditnames']<!--{/if}-->', defaultstyle = '$_G[style][defaultextstyle]', REPORTURL = '$_G[currenturl_encode]', SITEURL = '$_G[siteurl]', JSPATH = '$_G[setting][jspath]', CSSPATH = '$_G[setting][csspath]', DYNAMICURL = '{$_G[dynamicurl] or ''}';</script>
 	<!--{if DISCUZ_LANG == 'EN/'}-->
-	<script type="text/javascript" src="/source/language/EN/lang_js.js"></script>
+        <script type="text/javascript" src="/source/language/EN/lang_js.js?{VERHASH}"></script>
 	<!--{else}-->
-	<script type="text/javascript" src="/source/language/lang_js.js"></script>
+        <script type="text/javascript" src="/source/language/lang_js.js?{VERHASH}"></script>
 	<!--{/if}-->
 	<script type="text/javascript" src="{$_G[setting][jspath]}common.js?{VERHASH}"></script>
 	<!--{if empty($_GET['diy'])}--><!--{eval $_GET['diy'] = '';}--><!--{/if}-->

--- a/template/default/touch/common/header.htm
+++ b/template/default/touch/common/header.htm
@@ -14,9 +14,9 @@ $_G['setting']['seohead']
 
 <script type="text/javascript">var STYLEID = '{STYLEID}', STATICURL = '{STATICURL}', IMGDIR = '{IMGDIR}', VERHASH = '{VERHASH}', charset = '{CHARSET}', discuz_uid = '{$_G['uid']}', cookiepre = '{$_G['config']['cookie']['cookiepre']}', cookiedomain = '{$_G['config']['cookie']['cookiedomain']}', cookiepath = '{$_G['config']['cookie']['cookiepath']}', showusercard = '{$_G['setting']['showusercard']}', attackevasive = '{$_G['config']['security']['attackevasive']}', disallowfloat = '{$_G['setting']['disallowfloat']}', creditnotice = '<!--{if $_G['setting']['creditnotice']}-->$_G['setting']['creditnames']<!--{/if}-->', defaultstyle = '$_G['style']['defaultextstyle']', REPORTURL = '$_G['currenturl_encode']', SITEURL = '$_G['siteurl']', JSPATH = '$_G['setting']['jspath']';</script>
 <!--{if DISCUZ_LANG == 'EN/'}-->
-<script type="text/javascript" src="/source/language/EN/lang_js.js"></script>
+<script type="text/javascript" src="/source/language/EN/lang_js.js?{VERHASH}"></script>
 <!--{else}-->
-<script type="text/javascript" src="/source/language/lang_js.js"></script>
+<script type="text/javascript" src="/source/language/lang_js.js?{VERHASH}"></script>
 <!--{/if}-->
 <link rel="stylesheet" href="{STATICURL}image/mobile/style.css?{VERHASH}" type="text/css" media="all">
 <link rel="stylesheet" href="{STATICURL}image/mobile/font/dzmicon.css?{VERHASH}" type="text/css" media="all">


### PR DESCRIPTION
## Summary
- append `{VERHASH}` to language script references for cache busting

## Testing
- `composer validate --no-check-all`
- `php -l source/function/function_admincp.php`
- `php -l tests/check_discuz_login.php`
- `php tests/check_discuz_login.php`

------
https://chatgpt.com/codex/tasks/task_e_68529f3191308328afb1850aaf7ef677