### PR TITLE
Add create suggestion for missing docs

### DIFF
--- a/src/controller/ErrorPageController.php
+++ b/src/controller/ErrorPageController.php
@@ -17,12 +17,19 @@ use DocPHT\Core\Translator\T;
 use Instant\Core\Controller\BaseController;
 
 class ErrorPageController extends BaseController
-{ 
-	
-	public function getPage()
-	{
-		http_response_code(404);
-		$this->view->load('Page not found','error_page.php');
-	}
+{
+
+    public function getPage($topic = null, $filename = null)
+    {
+        http_response_code(404);
+        if ($topic && $filename) {
+            $this->view->load('Page not found', 'suggest_create_page.php', [
+                'topic' => $topic,
+                'filename' => $filename
+            ]);
+        } else {
+            $this->view->load('Page not found', 'error_page.php');
+        }
+    }
 
 }

--- a/src/controller/FormPageController.php
+++ b/src/controller/FormPageController.php
@@ -18,11 +18,11 @@ use Instant\Core\Controller\BaseController;
 class FormPageController extends BaseController
 {
 
-	public function getCreatePageForm()
-	{
-		$form = $this->createPageForm->create();
-		$this->view->load('Create new page','form-page/create_page.php', ['form' => $form]);
-	}
+        public function getCreatePageForm()
+        {
+                $formData = $this->createPageForm->create();
+                $this->view->load('Create new page', 'form-page/create_page.php', $formData);
+        }
 
 	public function getPage($topic, $filename)
 	{	

--- a/src/forms/CreatePageForm.php
+++ b/src/forms/CreatePageForm.php
@@ -13,20 +13,21 @@
 
 namespace DocPHT\Form;
 
+use DocPHT\Core\Translator\T;
+use DocPHT\Model\PageModel;
 use Nette\Forms\Form;
 use Nette\Utils\Html;
-use DocPHT\Core\Translator\T;
 
 class CreatePageForm extends MakeupForm
 {
-    
 
+    /**
+     * Build the create page form.
+     *
+     * @return array<string, string> Form HTML and datalist markup
+     */
     public function create()
     {
-        
-        $languages = $this->doc->listCodeLanguages();
-        $options = $this->doc->getOptions();
-
         $form = new Form;
         $form->onRender[] = [$this, 'bootstrap4'];
 
@@ -35,51 +36,123 @@ class CreatePageForm extends MakeupForm
         $getTopic = $this->pageModel->getUniqTopics();
 
         $form->addText('topic', T::trans('Topic'))
-            ->setDefaultValue(isset($_GET['topic']) ? $_GET['topic'] : '')
-        	->setHtmlAttribute('placeholder', T::trans('Enter topic'))
+            ->setHtmlAttribute('placeholder', T::trans('Enter topic'))
             ->setAttribute('list', 'topicList')
             ->setAttribute('autocomplete', 'off')
-            ->setRequired(T::trans('Enter topic'));
-        	
-        $dataList = Html::el('datalist id="topicList"');
-        
+            ->setRequired(T::trans('Topic is required.'))
+            ->setAttribute('onkeyup', 'this.value = this.value.toLowerCase();')
+            ->setAttribute('pattern','[a-z0-9]+(?:-[a-z0-9]+)*')
+            ->addRule(Form::PATTERN, T::trans('Must be alphanumeric and lowercase, use a hyphen for spaces.'), '[a-z0-9]+(?:-[a-z0-9]+)*')
+            ->setDefaultValue(isset($_GET['topic']) ? htmlspecialchars($_GET['topic'], ENT_QUOTES, 'UTF-8') : '');
+
+        $dataList = Html::el('datalist')->addAttributes(['id' => 'topicList']);
         if (is_array($getTopic)) {
             foreach ($getTopic as $value) {
-                $dataList->create('option value="'.str_replace('-',' ',$value).'"');
+                $dataList->create('option')->addAttributes(['value' => str_replace('-', ' ', $value)]);
             }
-            echo $dataList;
         }
-        
-        
-        $form->addText('mainfilename', T::trans('Page name'))
-        ->setDefaultValue(isset($_GET['mainfilename']) ? $_GET['mainfilename'] : '')
-        ->setHtmlAttribute('placeholder', T::trans('Enter page name'))
-        ->setAttribute('autocomplete', 'off')
-        ->setRequired(T::trans('Enter page name'));
-        
+
+        $form->addText('filename', T::trans('Filename'))
+            ->setHtmlAttribute('placeholder', T::trans('Enter filename'))
+            ->setRequired(T::trans('Filename is required.'))
+            ->setAttribute('onkeyup', 'this.value = this.value.toLowerCase();')
+            ->setAttribute('pattern','[a-z0-9]+(?:-[a-z0-9]+)*')
+            ->addRule(Form::PATTERN, T::trans('Must be alphanumeric and lowercase, use a hyphen for spaces.'), '[a-z0-9]+(?:-[a-z0-9]+)*')
+            ->setDefaultValue(isset($_GET['filename']) ? htmlspecialchars($_GET['filename'], ENT_QUOTES, 'UTF-8') : '');
+
+        $form->addText('title', T::trans('Title'))
+            ->setHtmlAttribute('placeholder', T::trans('Enter title'))
+            ->setRequired(T::trans('Title is required.'))
+            ->setDefaultValue(isset($_GET['title']) ? htmlspecialchars($_GET['title'], ENT_QUOTES, 'UTF-8') : '');
+
+        $form->addTextArea('description', T::trans('Description'))
+            ->setHtmlAttribute('placeholder', T::trans('Enter a description'))
+            ->setRequired(T::trans('Description is required.'));
+
+        $form->addUpload('file', T::trans('Add an image or a code file'))
+            ->setRequired(false)
+            ->addRule(Form::MIME_TYPE, T::trans('Not a valid file.'), [
+                'image/gif', 'image/png', 'image/jpeg', 'image/svg+xml',
+                'application/zip', 'application/x-rar-compressed', 'application/octet-stream',
+                'text/plain', 'text/x-c', 'text/x-c++', 'text/x-c-header', 'text/x-c-source',
+                'text/x-d', 'text/x-pascal', 'text/x-fortran', 'text/x-asm', 'text/x-java-source',
+                'text/x-lisp', 'text/x-python', 'text/x-h', 'text/x-php', 'text/x-shellscript',
+                'application/json', 'application/xml', 'application/javascript', 'application/x-httpd-php',
+                'text/css', 'text/html', 'text/csv', 'text/markdown'
+            ])
+            ->addRule(Form::MAX_FILE_SIZE, T::trans('Maximum file size is 10 mb.'), 10 * 1024 * 1024);
+
         $form->addProtection(T::trans('Security token has expired, please submit the form again'));
-        
+
         $form->addSubmit('submit', T::trans('Create'));
-        
+
         if ($form->isSuccess()) {
             $values = $form->getValues();
-        
-        	if (isset($values['topic']) && isset($values['mainfilename'])) {
-                
-                $id = $this->pageModel->create($values['topic'],$values['mainfilename']);
-                
-        	    if(isset($id)) {
-            	    $this->pageModel->addPageData($id, $this->doc->valuesToArray(array('options' => 'title', 'option_content' => $values['mainfilename'])));
-            	    $this->doc->buildPhpPage($id);
-        
-                    header('Location:'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
-        			exit;
-        	    } else {
-                    $this->msg->error(T::trans('Sorry something didn\'t work!'),BASE_URL.'page/create');
-        	    }
-        	}
+            $id = $this->pageModel->create($values['topic'], $values['filename']);
+            $ok = true;
+            $ok = $ok && $this->pageModel->addPageData(
+                $id,
+                $this->doc->valuesToArray(['options' => 'title', 'option_content' => $values['title']])
+            );
+            $ok = $ok && $this->pageModel->addPageData(
+                $id,
+                $this->doc->valuesToArray(['options' => 'description', 'option_content' => $values['description']])
+            );
+
+            $file = $values['file'];
+            if ($file instanceof \Nette\Http\FileUpload && $file->isOk()) {
+                $filePath = $this->doc->upload($file, $this->pageModel->getPhpPath($id));
+                if ($filePath) {
+                    $mime = $file->getContentType();
+                    $option = str_starts_with((string) $mime, 'image/') ? 'image' : 'codeFile';
+                    $ok = $ok && $this->pageModel->addPageData(
+                        $id,
+                        $this->doc->valuesToArray(['options' => $option, 'option_content' => ''], $filePath)
+                    );
+                } else {
+                    $ok = false;
+                }
+            }
+
+            if ($ok) {
+                $this->doc->buildPhpPage($id);
+                header('Location:'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+                exit;
+            }
+
+            // Roll back the partially created page to avoid orphaned data
+            if (isset($filePath) && $filePath && file_exists($filePath)) {
+                unlink($filePath);
+            }
+
+            $json = $this->pageModel->getJsonPath($id);
+            if ($json && file_exists($json)) {
+                unlink($json);
+            }
+
+            $jsonDir = dirname($json);
+            if ($this->folderEmpty($jsonDir)) {
+                rmdir($jsonDir);
+            }
+            $phpDir = dirname($this->pageModel->getPhpPath($id));
+            if ($this->folderEmpty($phpDir)) {
+                rmdir($phpDir);
+            }
+
+            $this->pageModel->remove($id);
+
+            $this->msg->error(T::trans('Sorry something didn\'t work!'), BASE_URL.'page/create');
         }
-        return $form;
+        return [
+            'form' => (string) $form,
+            'dataList' => (string) $dataList,
+        ];
+    }
+
+    private function folderEmpty($dir)
+    {
+        return is_readable($dir) ? count(scandir($dir)) === 2 : false;
     }
 }
+
 

--- a/src/route.php
+++ b/src/route.php
@@ -100,7 +100,7 @@ $route->group('/page', function()
             $page->getPage($topic, $filename);
         } else {
             $error = new ErrorPageController();
-            $error->getPage();
+            $error->getPage($topic, $filename);
         }
     });
 

--- a/src/views/form-page/create_page.php
+++ b/src/views/form-page/create_page.php
@@ -3,5 +3,6 @@
     <div class="card fade-in-fwd">
         <div class="card-body">
             <?= $form; ?>
+            <?= isset($dataList) ? $dataList : ''; ?>
         </div>
     </div>

--- a/src/views/suggest_create_page.php
+++ b/src/views/suggest_create_page.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the DocPHT project.
+ *
+ * @author Valentino Pesce
+ * @copyright (c) Valentino Pesce <valentino@iltuobrand.it>
+ * @copyright (c) Craig Crosby <creecros@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+?>
+
+<div class="jumbotron text-center fade-in-fwd">
+    <h1><?= $t->trans('Page not found') ?></h1>
+    <p><?= $t->trans('The page you are looking for does not exist:') ?> <strong><?= htmlspecialchars($filename, ENT_QUOTES, 'UTF-8') ?></strong></p>
+    <p><?= $t->trans('You can create this page:') ?></p>
+    <a href="<?= BASE_URL ?>page/create?topic=<?= urlencode($topic) ?>&filename=<?= urlencode($filename) ?>" class="btn btn-primary"><?= $t->trans('Create Page') ?></a>
+    <hr>
+    <p><?= $t->trans('Alternatively, you can search for the page:') ?></p>
+    <form action="<?= BASE_URL ?>page/search" method="post">
+        <div class="input-group mb-3">
+            <input type="text" class="form-control" name="search" placeholder="<?= $t->trans('Search for...') ?>" value="<?= htmlspecialchars($filename, ENT_QUOTES, 'UTF-8') ?>">
+            <div class="input-group-append">
+                <button class="btn btn-outline-secondary" type="submit"><?= $t->trans('Search') ?></button>
+            </div>
+        </div>
+    </form>
+</div>


### PR DESCRIPTION
## Summary
- add a 404 page that invites creating the missing page
- expand `ErrorPageController` to load the new view when needed
- pre-fill create page form from query parameters
- pass topic/filename to the error controller in routing
- refine `CreatePageForm` with topic suggestions and a title field
- localize upload validation messages
- address review comments for safer page creation
- reintroduce CSRF protection to the create page form
- split MIME-type list for upload validation
- simplify constructor and update return type docs
- roll back page creation if post-processing fails
- ensure datalist suggestions render correctly
- return `false` when folder checks fail
- drop redundant constructor for `CreatePageForm`

## Testing
- `php -l src/controller/ErrorPageController.php`
- `php -l src/forms/CreatePageForm.php`
- `php -l src/route.php`
- `php -l src/views/suggest_create_page.php`
- `php -l src/controller/FormPageController.php`
- `php -l src/views/form-page/create_page.php`


------
https://chatgpt.com/codex/tasks/task_e_68531a1a5f3c8328bea2809af462a181