### PR TITLE
Remove user language config, detect via HTTP header

### DIFF
--- a/src/core/Helper/DiscuzBridge.php
+++ b/src/core/Helper/DiscuzBridge.php
@@ -12,11 +12,9 @@ class DiscuzBridge
     {
         $adminModel = new AdminModel();
         if (!$adminModel->userExists($username)) {
-            $langHeader = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '';
             $adminModel->create([
                 'username' => $username,
                 'password' => $password ?? bin2hex(random_bytes(16)),
-                'translations' => (stripos($langHeader, 'zh') === false) ? 'en_EN' : 'zh_CN',
                 'admin' => false
             ]);
         }

--- a/src/core/Views/View.php
+++ b/src/core/Views/View.php
@@ -15,7 +15,6 @@
 namespace Instant\Core\Views;
 
 use DocPHT\Model\PageModel;
-use DocPHT\Model\AdminModel;
 use DocPHT\Core\Translator\T;
 use DocPHT\Model\BackupsModel;
 use DocPHT\Model\HomePageModel;
@@ -35,7 +34,6 @@ class View
 	public function __construct()
 	{
 		$this->pageModel = new PageModel();
-		$this->adminModel = new AdminModel();
 		$this->backupsModel = new BackupsModel();
 		$this->homePageModel = new HomePageModel();
 		$this->version = new VersionSelectForm();
@@ -44,35 +42,19 @@ class View
 
 	public function show($file, $data = null)
 	{
-		if (isset($_SESSION['Active'])) {
-			$adminModel = $this->adminModel;
-            $userLanguage = $adminModel->getUserTrans($_SESSION['Username']);
-
-			if (isset($userLanguage)) {
-				$t = new Translator($userLanguage);
-				$t->addLoader('array', new ArrayLoader());
-				if (file_exists('src/translations/'.$userLanguage.'.php')) {
-					include 'src/translations/'.$userLanguage.'.php';
-				} else {
-					include 'src/translations/'.LANGUAGE.'.php';
-				} 
-			} 
-		} elseif (file_exists('src/translations/'.LANGUAGE.'.php')) {
-			$t = new Translator(LANGUAGE);
-			$t->addLoader('array', new ArrayLoader());
-			include 'src/translations/'.LANGUAGE.'.php';
-		} else {
-			echo "Make sure that the config.php file is present in the config folder and that the language code is entered.";
-			exit;
-		}
+                $lang = T::detectLang();
+                $t = new Translator($lang);
+                $t->addLoader('array', new ArrayLoader());
+                if (file_exists('src/translations/'.$lang.'.php')) {
+                        include 'src/translations/'.$lang.'.php';
+                }
 		
 		if (is_array($data))
 		{
 			extract($data);
 		}
 		$this->pageModel;
-		$this->msg;
-		$this->adminModel;
+                $this->msg;
 		include 'src/views/'.$file;
 	}
 

--- a/src/core/translations/T.php
+++ b/src/core/translations/T.php
@@ -13,12 +13,37 @@
 
 namespace DocPHT\Core\Translator;
 
-use DocPHT\Model\AdminModel;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 
 class T
 {
+    /**
+     * Detect preferred language from HTTP headers
+     *
+     * @return string
+     */
+    public static function detectLang(): string
+    {
+        $accept = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '';
+        if ($accept) {
+            $parts = explode(',', $accept);
+            if (!empty($parts[0])) {
+                $locale = str_replace('-', '_', trim($parts[0]));
+                // try full locale
+                if (file_exists('src/translations/'.$locale.'.php')) {
+                    return $locale;
+                }
+                // try language only
+                $base = strtolower(substr($locale, 0, 2));
+                $candidate = $base.'_'.strtoupper($base);
+                if (file_exists('src/translations/'.$candidate.'.php')) {
+                    return $candidate;
+                }
+            }
+        }
+        return 'en_EN';
+    }
     /**
      * Trans static method for string translations
      *
@@ -27,30 +52,15 @@ class T
      *
      * @return string
      */
-    public static function trans($string, $array = null) 
+    public static function trans($string, $array = null)
     {
-        if (isset($_SESSION['Active'])) {
-			$adminModel = new AdminModel();
-            $userLanguage = $adminModel->getUserTrans($_SESSION['Username']);
-			
-			if (isset($userLanguage)) {
-				$t = new Translator($userLanguage);
-				$t->addLoader('array', new ArrayLoader());
-				if (file_exists('src/translations/'.$userLanguage.'.php')) {
-					include 'src/translations/'.$userLanguage.'.php';
-				} else {
-					include 'src/translations/'.LANGUAGE.'.php';
-				} 
-			} 
-		} elseif (file_exists('src/translations/'.LANGUAGE.'.php')) {
-			$t = new Translator(LANGUAGE);
-			$t->addLoader('array', new ArrayLoader());
-			include 'src/translations/'.LANGUAGE.'.php';
-		} else {
-			echo "Make sure that the config.php file is present in the config folder and that the language code is entered.";
-			exit;
-		}
-        
+        $lang = self::detectLang();
+        $t = new Translator($lang);
+        $t->addLoader('array', new ArrayLoader());
+        if (file_exists('src/translations/'.$lang.'.php')) {
+            include 'src/translations/'.$lang.'.php';
+        }
+
         if (isset($array)) {
             return $t->trans($string, $array);
         } else {

--- a/src/forms/TranslationsForm.php
+++ b/src/forms/TranslationsForm.php
@@ -25,31 +25,11 @@ class TranslationsForm extends MakeupForm
         $form = new Form;
         $form->onRender[] = [$this, 'bootstrap4'];
 
-        $form->addGroup(T::trans('Update translations for: ') . $_SESSION['Username']);
-            
-        $translations = json_decode(file_get_contents(realpath('src/translations/code-translations.json')), true);
-        asort($translations);
-        $form->addSelect('translations',T::trans('Language:'), $translations)
-        	->setPrompt(T::trans('Select an option'))
-        	->setHtmlAttribute('data-live-search','true')
-        	->setDefaultValue($this->adminModel->getUserTrans($_SESSION['Username']))
-        	->setRequired(T::trans('Select an option'));
-            error_log($this->adminModel->getUserTrans($_SESSION['Username']),0);
-        
-        $form->addProtection(T::trans('Security token has expired, please submit the form again'));
-        
-        $form->addSubmit('submit', T::trans('Update user translation'));
-        
-        if ($form->isSuccess()) {
-            $values = $form->getValues();
-            if (isset($_SESSION['Username']) && isset($values['translations'])) {
-                $this->adminModel->updateTrans($_SESSION['Username'], $values['translations']);
-                $this->msg->success(T::trans('Successful language change.'),BASE_URL.'admin');
-            } else {
-                $this->msg->error(T::trans('Sorry something didn\'t work!'),BASE_URL.'admin');
-            }
-            
-        }        
-		return $form;
-	}
+        $form->addGroup(T::trans('Language selection'));
+        $form->addText('info', T::trans('Current language'))
+            ->setHtmlAttribute('readonly', true)
+            ->setDefaultValue(T::detectLang());
+
+        return $form;
+        }
 }

--- a/src/model/AdminModel.php
+++ b/src/model/AdminModel.php
@@ -56,7 +56,6 @@ class AdminModel
         $data[] = array(
             'Username' => $values['username'],
             'Password' => password_hash($values['password'], PASSWORD_DEFAULT),
-            'Language' => $values['translations'],
             'Token'    => '',
             'Admin'    => $values['admin']
             );
@@ -98,12 +97,8 @@ class AdminModel
      */
     public function updateTrans($username, $translation)
     {
-        $data = $this->connect();
-        $key = array_search($username, array_column($data, 'Username'));
-        
-        $data[$key]['Language'] = $translation;
-        
-        return $this->disconnect(self::USERS, $data);
+        // language preference is now detected automatically
+        return true;
     }
     
     /**
@@ -115,10 +110,7 @@ class AdminModel
      */
     public function getUserTrans($username)
     {
-        $data = $this->connect();
-        $key = array_search($username, array_column($data, 'Username'));
-        
-        return $data[$key]['Language'];
+        return \DocPHT\Core\Translator\T::detectLang();
     }
     
     /**

--- a/src/views/admin/settings.php
+++ b/src/views/admin/settings.php
@@ -110,21 +110,6 @@
                     </div>
                 <?php endif ?>
 
-                <div class="col-md-4 grid-margin mb-4">
-                    <div class="card bg-docpht d-flex align-items-left">
-                        <a href="admin/translations" class="text-white">
-                            <div class="card-body shadow">
-                                <div class="d-flex flex-row align-items-left">
-                                        <i class="fa fa-language fa-3x" aria-hidden="true"></i>
-                                    <div class="ml-3">
-                                        <h6 class="text-white"><?= $t->trans('Select language'); ?></h6>
-                                        <p class="mt-2 text-white card-text"><small><?= $t->trans('Translations'); ?></small></p>
-                                    </div>
-                                </div>
-                            </div>
-                        </a>
-                    </div>
-                </div>
 
                 <div class="col-md-4 grid-margin mb-4">
                     <div class="card bg-docpht d-flex align-items-left">


### PR DESCRIPTION
## Summary
- drop per-user translation settings
- detect language from `HTTP_ACCEPT_LANGUAGE` header
- simplify translation form and admin settings

## Testing
- `composer install`
- `php -l src/core/translations/T.php`
- `php -l src/core/Views/View.php`
- `php -l src/forms/TranslationsForm.php`
- `php -l src/core/Helper/DiscuzBridge.php`
- `php -l src/model/AdminModel.php`


------
https://chatgpt.com/codex/tasks/task_e_68536b4a9f888328bbe31bb2da3f5380