### PR TITLE
Remove json and php paths from pages data

### DIFF
--- a/src/forms/PublishPageForm.php
+++ b/src/forms/PublishPageForm.php
@@ -36,8 +36,6 @@ class PublishPageForm extends MakeupForm
                         'slug' => $value['pages']['slug'],
                         'topic' => $value['pages']['topic'],
                         'filename' => $value['pages']['filename'],
-                        'phppath' => $value['pages']['phppath'],
-                        'jsonpath' => $value['pages']['jsonpath'],
                         'published' => $published,
                         'home' => $value['pages']['home']
                     ]

--- a/src/model/BackupsModel.php
+++ b/src/model/BackupsModel.php
@@ -31,7 +31,7 @@ class BackupsModel extends PageModel
     public function checkBackups($file_path)
     {
         $zipData = new \ZipArchive();
-        if ($zipData->open($file_path) === TRUE) {
+        if ($zipData->open($file_path) === true) {
 
             $check = $zipData->locateName('json/pages.json') !== false;
             if ($check) {
@@ -47,10 +47,10 @@ class BackupsModel extends PageModel
             }
             $zipData->close();
 
-            return $check ? TRUE : FALSE;
+            return $check;
         } else {
 
-        return FALSE;
+        return false;
 
         }
         
@@ -66,7 +66,7 @@ class BackupsModel extends PageModel
     public function getZipList($file)
     {
         $zip = new \ZipArchive(); 
-        if ($zip->open($file) == TRUE) {
+        if ($zip->open($file) === true) {
             for ($i = 0; $i < $zip->numFiles; $i++) {
                 $filename[] = $zip->getNameIndex($i);
             }
@@ -113,7 +113,7 @@ class BackupsModel extends PageModel
             
             return $array;
         } else {
-            return FALSE;
+            return false;
         }
 
     }
@@ -173,9 +173,9 @@ class BackupsModel extends PageModel
     {
         if (file_exists($path)) {
             unlink($path);
-            return TRUE;
+            return true;
         } else {
-            return FALSE;
+            return false;
         }
         
     }

--- a/src/model/BackupsModel.php
+++ b/src/model/BackupsModel.php
@@ -30,25 +30,28 @@ class BackupsModel extends PageModel
      */
     public function checkBackups($file_path)
     {
-        $zipData = new \ZipArchive(); 
+        $zipData = new \ZipArchive();
         if ($zipData->open($file_path) === TRUE) {
 
-            (is_bool($zipData->locateName('json/pages.json')) === TRUE) ? $check = FALSE : $check = TRUE; 
+            $check = $zipData->locateName('json/pages.json') !== false;
             if ($check) {
-                $backupPages = json_decode(file_get_contents("zip://".$file_path."#json/pages.json"),true);
+                $backupPages = json_decode(file_get_contents("zip://".$file_path."#json/pages.json"), true);
                 foreach ($backupPages as $pages) {
                     $phpPath = 'pages/'.$pages['pages']['slug'].'.php';
                     $jsonPath = 'json/'.$pages['pages']['slug'].'.json';
-                    (is_bool($zipData->locateName($phpPath)) === TRUE || is_bool($zipData->locateName($jsonPath)) === TRUE) ? $check = FALSE : $check = TRUE;
+                    if ($zipData->locateName($phpPath) === false || $zipData->locateName($jsonPath) === false) {
+                        $check = false;
+                        break;
+                    }
                 }
             }
             $zipData->close();
-            
-            if ($check) { return TRUE; } else { return FALSE; }
+
+            return $check ? TRUE : FALSE;
         } else {
-        
+
         return FALSE;
-        
+
         }
         
     }

--- a/src/model/BackupsModel.php
+++ b/src/model/BackupsModel.php
@@ -37,7 +37,9 @@ class BackupsModel extends PageModel
             if ($check) {
                 $backupPages = json_decode(file_get_contents("zip://".$file_path."#json/pages.json"),true);
                 foreach ($backupPages as $pages) {
-                    (is_bool($zipData->locateName($pages['pages']['phppath'])) === TRUE || is_bool($zipData->locateName($pages['pages']['jsonpath'])) === TRUE) ? $check = FALSE : $check = TRUE; 
+                    $phpPath = 'pages/'.$pages['pages']['slug'].'.php';
+                    $jsonPath = 'json/'.$pages['pages']['slug'].'.json';
+                    (is_bool($zipData->locateName($phpPath)) === TRUE || is_bool($zipData->locateName($jsonPath)) === TRUE) ? $check = FALSE : $check = TRUE;
                 }
             }
             $zipData->close();

--- a/src/model/HomePageModel.php
+++ b/src/model/HomePageModel.php
@@ -32,7 +32,7 @@ class HomePageModel extends PageModel
         if (!is_null($data)) {
             foreach($data as $value){
                 if($value['pages']['home'] == 1) {
-                  $path = $value['pages']['phppath'];  
+                  $path = 'pages/'.$value['pages']['slug'].'.php';
                   break;
                 }
             } 
@@ -71,8 +71,6 @@ class HomePageModel extends PageModel
                         'slug' => $value['pages']['slug'],
                         'topic' => $value['pages']['topic'],
                         'filename' => $value['pages']['filename'],
-                        'phppath' => $value['pages']['phppath'],
-                        'jsonpath' => $value['pages']['jsonpath'],
                         'published' => $published,
                         'home' => $home
                 ]

--- a/src/model/PageModel.php
+++ b/src/model/PageModel.php
@@ -122,17 +122,12 @@ class PageModel
             };
         }   
         
-		$phpPath = 'pages/'.$slug.'.php';
-        $jsonPath = 'json/'.$slug.'.json';
-        
         $data[] = array(
             'pages' => [
                     'id' => $id,
                     'slug' => $slug,
                     'topic' => $topic,
                     'filename' => $filename,
-                    'phppath' => $phpPath,
-                    'jsonpath' => $jsonPath,
                     'published' => 0,
                     'home' => 0
             ]);
@@ -239,10 +234,9 @@ class PageModel
      */
     public function getPhpPath($id)
     {
-        $data = $this->connect();
-        $key = $this->findKey($data, $id);
+        $slug = $this->getSlug($id);
 
-        return $data[$key]['pages']['phppath'];
+        return 'pages/'.$slug.'.php';
     }
     
     /**
@@ -269,13 +263,10 @@ class PageModel
      */
     public function getJsonPath($id)
     {
-        $data = $this->connect();
-        $key = $this->findKey($data, $id);
-        
-        if (isset($data[$key])) {
-            return $data[$key]['pages']['jsonpath'];
-        }
-    }    
+        $slug = $this->getSlug($id);
+
+        return 'json/'.$slug.'.json';
+    }
     
     /**
      * getAllFromKey
@@ -369,9 +360,12 @@ class PageModel
     public function getId($path)
     {
         $data = $this->connect();
-        $key = array_search($path, array_column($data, 'phppath'));
-        
-        return $data[$key]['pages']['id'];
+        foreach ($data as $value) {
+            $phpPath = 'pages/'.$value['pages']['slug'].'.php';
+            if ($phpPath === $path) {
+                return $value['pages']['id'];
+            }
+        }
     }
     
     /**

--- a/src/model/PageModel.php
+++ b/src/model/PageModel.php
@@ -236,6 +236,10 @@ class PageModel
     {
         $slug = $this->getSlug($id);
 
+        if (empty($slug)) {
+            return null;
+        }
+
         return 'pages/'.$slug.'.php';
     }
     
@@ -251,7 +255,7 @@ class PageModel
         $data = $this->connect();
         $key = $this->findKey($data, $id);
 
-        return $data[$key]['pages']['slug'];
+        return isset($data[$key]) ? $data[$key]['pages']['slug'] : null;
     }
     
     /**
@@ -264,6 +268,10 @@ class PageModel
     public function getJsonPath($id)
     {
         $slug = $this->getSlug($id);
+
+        if (empty($slug)) {
+            return null;
+        }
 
         return 'json/'.$slug.'.json';
     }
@@ -366,6 +374,8 @@ class PageModel
                 return $value['pages']['id'];
             }
         }
+
+        return null;
     }
     
     /**


### PR DESCRIPTION
## Summary
- simplify `pages.json` structure by removing stored file paths
- compute JSON and PHP paths dynamically

## Testing
- `php -l src/model/PageModel.php`
- `php -l src/model/HomePageModel.php`
- `php -l src/forms/PublishPageForm.php`
- `php -l src/model/BackupsModel.php`


------
https://chatgpt.com/codex/tasks/task_e_6853b82eae9c8328a308b43b0a14dea5