### PR TITLE
Remove unused imports in forms

### DIFF
--- a/src/forms/AddSectionForm.php
+++ b/src/forms/AddSectionForm.php
@@ -14,7 +14,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 
 class AddSectionForm extends MakeupForm

--- a/src/forms/BackupsForms.php
+++ b/src/forms/BackupsForms.php
@@ -14,7 +14,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 use DocPHT\Model\PageModel;
 

--- a/src/forms/DeletePageForm.php
+++ b/src/forms/DeletePageForm.php
@@ -13,9 +13,6 @@
 
 namespace DocPHT\Form;
 
-use Nette\Forms\Form;
-use Nette\Utils\Html;
-use DocPHT\Core\Translator\T;
 
 class DeletePageForm extends MakeupForm
 {

--- a/src/forms/HomePageForm.php
+++ b/src/forms/HomePageForm.php
@@ -13,7 +13,6 @@
 
 namespace DocPHT\Form;
 
-use DocPHT\Core\Translator\T;
 
 class HomePageForm extends MakeupForm
 {

--- a/src/forms/InsertSectionForm.php
+++ b/src/forms/InsertSectionForm.php
@@ -14,7 +14,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 
 class InsertSectionForm extends MakeupForm

--- a/src/forms/LoginForm.php
+++ b/src/forms/LoginForm.php
@@ -15,7 +15,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 use DocPHT\Controller\LoginController;
 

--- a/src/forms/MakeupForm.php
+++ b/src/forms/MakeupForm.php
@@ -20,7 +20,6 @@ use DocPHT\Model\VersionModel;
 use DocPHT\Model\BackupsModel;
 use DocPHT\Model\HomePageModel;
 use DocPHT\Model\AdminModel;
-use DocPHT\Core\Translator\T;
 use Plasticbrain\FlashMessages\FlashMessages;
 
 class MakeupForm

--- a/src/forms/ModifySectionForm.php
+++ b/src/forms/ModifySectionForm.php
@@ -14,7 +14,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 
 class ModifySectionForm extends MakeupForm

--- a/src/forms/PublishPageForm.php
+++ b/src/forms/PublishPageForm.php
@@ -13,7 +13,6 @@
 
 namespace DocPHT\Form;
 
-use DocPHT\Core\Translator\T;
 
 class PublishPageForm extends MakeupForm
 {

--- a/src/forms/RemoveSectionForm.php
+++ b/src/forms/RemoveSectionForm.php
@@ -14,7 +14,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 
 class RemoveSectionForm extends MakeupForm

--- a/src/forms/SortSectionForm.php
+++ b/src/forms/SortSectionForm.php
@@ -13,9 +13,6 @@
 
 namespace DocPHT\Form;
 
-use Nette\Forms\Form;
-use Nette\Utils\Html;
-use DocPHT\Core\Translator\T;
 
 class SortSectionForm extends MakeupForm
 {

--- a/src/forms/TranslationsForm.php
+++ b/src/forms/TranslationsForm.php
@@ -15,7 +15,6 @@ namespace DocPHT\Form;
 
 use DocPHT\Core\Translator\T;
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 
 class TranslationsForm extends MakeupForm
 {

--- a/src/forms/UpdatePageForm.php
+++ b/src/forms/UpdatePageForm.php
@@ -14,7 +14,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 
 class UpdatePageForm extends MakeupForm

--- a/src/forms/UploadLogoForm.php
+++ b/src/forms/UploadLogoForm.php
@@ -14,7 +14,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 
 class UploadLogoForm extends MakeupForm

--- a/src/forms/VersionForms.php
+++ b/src/forms/VersionForms.php
@@ -14,7 +14,6 @@
 namespace DocPHT\Form;
 
 use Nette\Forms\Form;
-use Nette\Utils\Html;
 use DocPHT\Core\Translator\T;
 
 class VersionForms extends MakeupForm


### PR DESCRIPTION
## Summary
- drop unused `Nette\Utils\Html` imports from several forms
- drop unused `Translator\T` imports in some classes
- clean up unused import groups in DeletePageForm and SortSectionForm

## Testing
- `php -l src/forms/AddSectionForm.php`
- `php -l src/forms/BackupsForms.php`
- `php -l src/forms/VersionForms.php`
- `php -l src/forms/UploadLogoForm.php`
- `php -l src/forms/UpdatePageForm.php`
- `php -l src/forms/TranslationsForm.php`
- `php -l src/forms/ModifySectionForm.php`
- `php -l src/forms/LoginForm.php`
- `php -l src/forms/RemoveSectionForm.php`
- `php -l src/forms/InsertSectionForm.php`
- `php -l src/forms/DeletePageForm.php`
- `php -l src/forms/SortSectionForm.php`
- `php -l src/forms/HomePageForm.php`
- `php -l src/forms/MakeupForm.php`
- `php -l src/forms/PublishPageForm.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_6853da69c9c48328ab60385d257a367c