### PR TITLE
Improve admin settings

### DIFF
--- a/src/controller/AdminController.php
+++ b/src/controller/AdminController.php
@@ -18,11 +18,20 @@ use Instant\Core\Controller\BaseController;
 class AdminController extends BaseController
 {
 
-	public function settings()
-	{
-		$newAppVersion = $this->newAppVersion->check();
-		$this->view->load('Admin','admin/settings.php', ['newAppVersion' => $newAppVersion]);
-	}
+        public function settings()
+        {
+                $newAppVersion = $this->newAppVersion->check();
+
+                $admin = false;
+                if (isset($_SESSION['Username'])) {
+                        $admin = $this->adminModel->checkUserIsAdmin($_SESSION['Username']);
+                }
+
+                $this->view->load('Admin','admin/settings.php', [
+                        'newAppVersion' => $newAppVersion,
+                        'admin' => $admin
+                ]);
+        }
 
 	public function backup()
 	{

--- a/src/views/admin/settings.php
+++ b/src/views/admin/settings.php
@@ -15,7 +15,7 @@
 
     <?php include 'src/views/partial/sidebar_button.php'; ?>
 
-    <?php $admin = $this->adminModel->checkUserIsAdmin($_SESSION['Username']); ?>
+    <?php $admin = $admin ?? false; ?>
 
     <div class="card fade-in-fwd">
         <div class="card-body">


### PR DESCRIPTION
## Summary
- avoid calling checkUserIsAdmin when username isn't set
- keep using passed `admin` variable in the settings view

## Testing
- `php -l src/controller/AdminController.php`
- `php -l src/views/admin/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_6853d60b95008328b63d9a503011e6a2