### PR TITLE
Fix tag search links

### DIFF
--- a/template/default/forum/collection_list.htm
+++ b/template/default/forum/collection_list.htm
@@ -25,7 +25,7 @@
 					<span class="ctag_keyword">
 						<!--{eval $keycount=0;}-->
 						<!--{loop $collectionvalues['arraykeyword'] $unique_keyword}-->
-							{if $keycount},&nbsp;{/if}<a href="search.php?mod={if $_G['setting']['search']['collection']['status']}collection{else}forum{/if}&srchtxt={echo rawurlencode($unique_keyword)}&formhash={FORMHASH}&searchsubmit=true&source=collectionsearch" target="_blank" class="xi2">$unique_keyword</a>
+{if $keycount},&nbsp;{/if}<a href="misc.php?mod=tag&name={echo rawurlencode($unique_keyword)}" target="_blank" class="xi2">$unique_keyword</a>
 							<!--{eval $keycount++;}-->
 						<!--{/loop}-->
 					</span>

--- a/template/default/forum/collection_view.htm
+++ b/template/default/forum/collection_view.htm
@@ -120,7 +120,7 @@
 						<p class="mbn">
 							{lang collection_keywords}
 							<!--{loop $_G['collection']['arraykeyword'] $unique_keyword}-->
-								<a href="search.php?mod={if $_G['setting']['search']['collection']['status']}collection{else}forum{/if}&srchtxt={echo rawurlencode($unique_keyword)}&formhash={FORMHASH}&searchsubmit=true&source=collectionsearch" target="_blank" class="xi2">$unique_keyword</a>&nbsp;
+                                                               <a href="misc.php?mod=tag&name={echo rawurlencode($unique_keyword)}" target="_blank" class="xi2">$unique_keyword</a>&nbsp;
 							<!--{/loop}-->
 						</p>
 					<!--{/if}-->

--- a/template/default/touch/forum/collection_list.htm
+++ b/template/default/touch/forum/collection_list.htm
@@ -35,7 +35,7 @@
 			<!--{if $collectionvalues['arraykeyword']}-->
 			<!--{eval $keycount=0;}-->
 			<!--{loop $collectionvalues['arraykeyword'] $unique_keyword}-->
-				<li class="mr"><a href="search.php?mod={if $_G['setting']['search']['collection']['status']}collection{else}forum{/if}&srchtxt={echo rawurlencode($unique_keyword)}&formhash={FORMHASH}&searchsubmit=true&source=collectionsearch">#$unique_keyword</a></li>
+                               <li class="mr"><a href="misc.php?mod=tag&name={echo rawurlencode($unique_keyword)}">#$unique_keyword</a></li>
 			<!--{eval $keycount++;}-->
 			<!--{/loop}-->
 			<!--{/if}-->


### PR DESCRIPTION
## Summary
- update thread collection tag search links to use misc.php
- update tag links in touch version and collection view

## Testing
- `php tests/check_discuz_login.php`
- `curl -s 127.0.0.1/forum.php?mod=collection | grep -m 1 -n "ctag_keyword"`

------
https://chatgpt.com/codex/tasks/task_e_6854b3cba6d08328a3a63af79d1fffcb