### PR TITLE
Fix mention regex to ignore email addresses

### DIFF
--- a/source/class/extend/extend_thread_allowat.php
+++ b/source/class/extend/extend_thread_allowat.php
@@ -20,7 +20,7 @@ class extend_thread_allowat extends extend_thread_base {
 
 		if($this->group['allowat']) {
 			$this->atlist = $atlist_tmp = array();
-			preg_match_all("/@([^\r\n]*?)\s/i", $parameters['message'].' ', $atlist_tmp);
+                        preg_match_all('/(?:^|\s)@([^\r\n@\s]+)(?=\s)/', $parameters['message'].' ', $atlist_tmp);
 			$atlist_tmp = array_slice(array_unique($atlist_tmp[1]), 0, $this->group['allowat']);
 			if(!empty($atlist_tmp)) {
 				if(!$this->setting['at_anyone']) {
@@ -56,7 +56,7 @@ class extend_thread_allowat extends extend_thread_base {
 	public function before_newreply($parameters) {
 		if($this->group['allowat']) {
 			$this->atlist = $atlist_tmp = $ateduids = array();
-			preg_match_all("/@([^\r\n]*?)\s/i", $parameters['message'].' ', $atlist_tmp);
+                        preg_match_all('/(?:^|\s)@([^\r\n@\s]+)(?=\s)/', $parameters['message'].' ', $atlist_tmp);
 			$atlist_tmp = array_slice(array_unique($atlist_tmp[1]), 0, $this->group['allowat']);
 			$atnum = $maxselect = 0;
 			foreach(C::t('home_notification')->fetch_all_by_authorid_fromid($this->member['uid'], $this->thread['tid'], 'at') as $row) {
@@ -117,7 +117,7 @@ class extend_thread_allowat extends extend_thread_base {
 				$ateduids[$row['uid']] = $row['uid'];
 			}
 			$maxselect = $this->group['allowat'] - $atnum;
-			preg_match_all("/@([^\r\n]*?)\s/i", $parameters['message'].' ', $atlist_tmp);
+                        preg_match_all('/(?:^|\s)@([^\r\n@\s]+)(?=\s)/', $parameters['message'].' ', $atlist_tmp);
 			$atlist_tmp = array_slice(array_unique($atlist_tmp[1]), 0, $this->group['allowat']);
 			if($maxselect > 0 && !empty($atlist_tmp)) {
 				if(empty($this->setting['at_anyone'])) {

--- a/source/include/post/post_newreply.php
+++ b/source/include/post/post_newreply.php
@@ -108,7 +108,7 @@ if($_G['setting']['commentnumber'] && !empty($_GET['comment'])) {
 			'commentmsg' => $comment
 		));
 	}
-	preg_match_all('/@([^\r\n]*?)\s/i', $comment.' ', $matches);
+        preg_match_all('/(?:^|\s)@([^\r\n@\s]+)(?=\s)/', $comment.' ', $matches);
 	if (!empty($matches[1])) {
 		$atlist_tmp = array_unique($matches[1]);
 		foreach ($atlist_tmp as $username) {


### PR DESCRIPTION
## Summary
- improve mention list regex in `extend_thread_allowat`
- update regex when parsing new reply comments

## Testing
- `php -l source/class/extend/extend_thread_allowat.php`
- `php -l source/include/post/post_newreply.php`


------
https://chatgpt.com/codex/tasks/task_e_6854c6fdab50832881d4d112e2a8c054