### PR TITLE
Fix at-mention regex

### DIFF
--- a/source/class/extend/extend_thread_allowat.php
+++ b/source/class/extend/extend_thread_allowat.php
@@ -15,7 +15,7 @@ class extend_thread_allowat extends extend_thread_base {
 
        protected function extract_mentions($message, $limit) {
                preg_match_all('/(?<!\S)@\K[^\r\n@\s]+(?=\s)/', $message.' ', $m);
-               $m = array_unique($m[0] ?? $m);
+               $m = array_unique($m[0]);
                $m = array_filter($m, function($v) {
                        $len = dstrlen($v);
                        return $len >= 3 && $len <= 15;

--- a/source/include/post/post_newreply.php
+++ b/source/include/post/post_newreply.php
@@ -109,7 +109,7 @@ if($_G['setting']['commentnumber'] && !empty($_GET['comment'])) {
 		));
 	}
 preg_match_all('/(?<!\S)@\K[^\r\n@\s]+(?=\s)/', $comment.' ', $matches);
-$matches = array_unique($matches[0] ?? $matches);
+$matches = array_unique($matches[0]);
 $matches = array_filter($matches, function($v) {
     $len = dstrlen($v);
     return $len >= 3 && $len <= 15;


### PR DESCRIPTION
## Summary
- revert username sanitization changes
- tweak mention regex to use `@\K` for cleaner matches

## Testing
- `php -l source/class/extend/extend_thread_allowat.php`


------
https://chatgpt.com/codex/tasks/task_e_685538756dc88328b798b92016480f73