### PR TITLE
Fix ajax.js undefined string check

### DIFF
--- a/static/js/ajax.js
+++ b/static/js/ajax.js
@@ -66,7 +66,7 @@ function _ajaxpost(formid, showid, waitid, showidclass, submitbtn, recall) {
                                s = lng['int_error'];
 			}
 		}
-		if(s != '' && s.indexOf('ajaxerror') != -1) {
+               if(s && s.indexOf('ajaxerror') != -1) {
 			evalscript(s);
 			evaled = true;
 		}


### PR DESCRIPTION
## Summary
- handle undefined AJAX response in `static/js/ajax.js`


------
https://chatgpt.com/codex/tasks/task_e_685550c27e6083288a0bd2faf30913b8