### PR TITLE
Fix session regeneration without active session

### DIFF
--- a/src/core/Helper/DiscuzBridge.php
+++ b/src/core/Helper/DiscuzBridge.php
@@ -18,6 +18,9 @@ class DiscuzBridge
                 'admin' => false
             ]);
         }
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
         session_regenerate_id(true);
         $_SESSION['PREV_USERAGENT'] = $_SERVER['HTTP_USER_AGENT'];
         $_SESSION['Username'] = $username;


### PR DESCRIPTION
## Summary
- avoid calling `session_regenerate_id` when the session hasn't started

## Testing
- `php -l src/core/Helper/DiscuzBridge.php`
- `php -l src/controller/LoginController.php`
- `php tests/check_discuz_login.php | head`

------
https://chatgpt.com/codex/tasks/task_e_6855501fefdc8328acfa6fefe5ac9703