### PR TITLE
Fix Discuz! querysafe error for @ mention

### DIFF
--- a/source/class/extend/extend_thread_allowat.php
+++ b/source/class/extend/extend_thread_allowat.php
@@ -45,7 +45,7 @@ class extend_thread_allowat extends extend_thread_base {
 				} else {
                                         foreach ($atlist_tmp as $username) {
                                                 $stripped_username = str_replace(' ', '', $username);
-                                                $uid = DB::result_first('SELECT uid FROM %t WHERE REPLACE(username, " ", "")=%s', array('common_member', $stripped_username));
+            $uid = DB::result_first("SELECT uid FROM %t WHERE REPLACE(username, ' ', '')=%s", array('common_member', $stripped_username));
                                                 $this->atlist[$uid] = $username;
 					}
 				}
@@ -94,7 +94,7 @@ class extend_thread_allowat extends extend_thread_base {
 				} else {
                                         foreach ($atlist_tmp as $username) {
                                                 $stripped_username = str_replace(' ', '', $username);
-                                                $uid = DB::result_first('SELECT uid FROM %t WHERE REPLACE(username, " ", "")=%s', array('common_member', $stripped_username));
+                                                $uid = DB::result_first("SELECT uid FROM %t WHERE REPLACE(username, ' ', '')=%s", array('common_member', $stripped_username));
                                                 if(!in_array($uid, $ateduids)) {
 							$this->atlist[$uid] = $username;
 							if(count($this->atlist) == $maxselect) {
@@ -147,7 +147,7 @@ class extend_thread_allowat extends extend_thread_base {
 				} else {
                                         foreach ($atlist_tmp as $username) {
                                                 $stripped_username = str_replace(' ', '', $username);
-                                                $uid = DB::result_first('SELECT uid FROM %t WHERE REPLACE(username, " ", "")=%s', array('common_member', $stripped_username));
+                                                $uid = DB::result_first("SELECT uid FROM %t WHERE REPLACE(username, ' ', '')=%s", array('common_member', $stripped_username));
                                                 if(!in_array($uid, $ateduids)) {
 							$this->atlist[$uid] = $username;
 							if(count($this->atlist) == $maxselect) {

--- a/source/include/post/post_newreply.php
+++ b/source/include/post/post_newreply.php
@@ -118,7 +118,7 @@ if (!empty($matches)) {
 	$atlist_tmp = $matches;
                 foreach ($atlist_tmp as $username) {
                         $stripped_username = str_replace(' ', '', $username);
-                        $uid = DB::result_first('SELECT uid FROM %t WHERE REPLACE(username, " ", "")=%s', array('common_member', $stripped_username));
+        $uid = DB::result_first("SELECT uid FROM %t WHERE REPLACE(username, ' ', '')=%s", array('common_member', $stripped_username));
 			if ($uid && $uid != $_G['uid']) {
 				notification_add(
 					$uid,


### PR DESCRIPTION
## Summary
- use single quotes when removing spaces from usernames in @ mention queries

## Testing
- `php -l source/class/extend/extend_thread_allowat.php`
- `php -l source/include/post/post_newreply.php`


------
https://chatgpt.com/codex/tasks/task_e_685563efbbc88328b198296a1abe8779