### PR TITLE
Fix URI logging

### DIFF
--- a/source/class/discuz/discuz_error.php
+++ b/source/class/discuz/discuz_error.php
@@ -349,7 +349,7 @@ EOT;
 		$ip = getglobal('clientip');
 
 		$user = '<b>User:</b> uid='.intval($uid).'; IP='.$ip.'; RIP:'.$_SERVER['REMOTE_ADDR'];
-		$uri = 'Request: '.dhtmlspecialchars(discuz_error::clear($_SERVER['REQUEST_URI']));
+		$uri = 'Request: '.discuz_error::clear($_SERVER['REQUEST_URI']);
 		$message = "<?PHP exit;?>\t{$time}\t$message\t$hash\t$user $uri\n";
 		if($fp = @fopen($file, 'rb')) {
 			$lastlen = 50000;


### PR DESCRIPTION
## Summary
- remove HTML escaping from request URI in error logger

## Testing
- `php -l source/class/discuz/discuz_error.php`
- `php tests/check_discuz_login.php`

------
https://chatgpt.com/codex/tasks/task_e_68557d0b4190832883e78c7dbb9f7d9f