### PR TITLE
Remove unused memory debug value

### DIFF
--- a/source/function/function_core.php
+++ b/source/function/function_core.php
@@ -1556,9 +1556,8 @@ function debuginfo() {
 	if(getglobal('setting/debug')) {
 		$_G['debuginfo'] = array(
 		    'time' => number_format((microtime(true) - $_G['starttime']), 6),
-		    'queries' => DB::object()->querynum,
-		    'memory' => ucwords(C::memory()->type)
-		    );
+                    'queries' => DB::object()->querynum,
+                    );
 		if(DB::object()->slaveid) {
 			$_G['debuginfo']['queries'] = 'Total '.DB::object()->querynum.', Slave '.DB::object()->slavequery;
 		}


### PR DESCRIPTION
## Summary
- clean up debuginfo by removing unused `memory` info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685824f099048328bbff120ec4523b74