### PR TITLE
Fix album view restrictions

### DIFF
--- a/source/include/thread/thread_album.php
+++ b/source/include/thread/thread_album.php
@@ -26,9 +26,6 @@ foreach(C::t('forum_attachment_n')->fetch_all_by_id('tid:'.$_G['tid'], 'tid', $_
 	if($_G['forum_threadpay'] && !in_array($attach['aid'], $freeattachids)) {
 		continue;
 	}
-	if($attach['uid'] != $_G['forum_thread']['authorid'] && (!defined('IN_MOBILE') || IN_MOBILE != 2)) {
-		continue;
-	}
 	if($attach['isimage'] && !$_G['setting']['attachimgpost']) {
 		$attach['isimage'] = 0;
 	}
@@ -64,7 +61,7 @@ foreach($attachmentlist as $attach) {
 }
 
 if(empty($imglist)) {
-	showmessage('author_not_uploadpic');
+	showmessage('thread_no_uploadpic');
 }
 
 foreach($postlist as $key=>$subpost) {

--- a/source/language/EN/lang_message.php
+++ b/source/language/EN/lang_message.php
@@ -1075,7 +1075,7 @@ $lang = array (
 	'no_privilege_livethread'	=> 'Sorry, you have no permission to set live posts',//'抱歉，您没有权限设置直播帖',
 	'portal_category_has_no_folder_name'	=> 'Sorry, the article category directory name is not set',//'抱歉，文章所属的频道没有设置目录名称',
 	'noreply_replynum_error'	=> 'Sorry, you have reached the upper limit of the thread replies.',//'对不起，你已经达到本主题的回帖上限。',
-	'author_not_uploadpic'		=> 'The user have no uploaded images',//'楼主暂时没有上传图片',
+       'thread_no_uploadpic' => 'No images have been uploaded in this thread',//'本主题暂无图片',
 	'noreply_yourself_error'	=> 'You can not vote on your own posts',//'您不能对自己的回帖进行投票',
 	'noreply_voted_error'		=> 'You have already voted this poll',//'您已经对此回帖投过票了',
 

--- a/source/language/TC/lang_message.php
+++ b/source/language/TC/lang_message.php
@@ -1110,7 +1110,7 @@ $lang = array (
   'no_privilege_livethread' => '抱歉，您沒有權限設置直播帖',
   'portal_category_has_no_folder_name' => '抱歉，文章所屬的頻道沒有設置目錄名稱',
   'noreply_replynum_error' => '對不起，你已經達到本主題的回帖上限。',
-  'author_not_uploadpic' => '樓主暫時沒有上傳圖片',
+  'thread_no_uploadpic' => '本主題暫無圖片',
   'noreply_yourself_error' => '您不能對自己的回帖進行投票',
   'noreply_voted_error' => '您已經對此回帖投過票了',
 

--- a/source/language/lang_message.php
+++ b/source/language/lang_message.php
@@ -1110,7 +1110,7 @@ $lang = array (
   'no_privilege_livethread' => '抱歉，您没有权限设置直播帖',
   'portal_category_has_no_folder_name' => '抱歉，文章所属的频道没有设置目录名称',
   'noreply_replynum_error' => '对不起，你已经达到本主题的回帖上限。',
-  'author_not_uploadpic' => '楼主暂时没有上传图片',
+  'thread_no_uploadpic' => '本主题暂无图片',
   'noreply_yourself_error' => '您不能对自己的回帖点赞',
   'noreply_voted_error' => '您已经对此回帖点过赞了',
 


### PR DESCRIPTION
## Summary
- allow viewing images from all posters in thread album
- rename `author_not_uploadpic` error to `thread_no_uploadpic`
- update language packs for new message
- update English comment for album message

## Testing
- `php -l source/include/thread/thread_album.php`
- `php -l source/language/EN/lang_message.php`
- `php -l source/language/TC/lang_message.php`
- `php -l source/language/lang_message.php`


------
https://chatgpt.com/codex/tasks/task_e_68583048fa848328927ec273bdf9421e