### PR TITLE
Hide tag suggestion form for guests

### DIFF
--- a/template/default/forum/viewthread.htm
+++ b/template/default/forum/viewthread.htm
@@ -353,6 +353,7 @@
 
 $_G['forum_tagscript']
 
+<!--{if $_G['uid']}-->
 <div id="suggestTagsWrapper" class="mtm">
     <button id="suggestTagsButton" class="pn"><span>{lang suggest_tags}</span></button>
     <div id="suggestTagsInputArea" style="display:none" class="ptm">
@@ -363,6 +364,7 @@ $_G['forum_tagscript']
         <button id="cancelSuggestTags" class="pn"><span>{lang cancel}</span></button>
     </div>
 </div>
+<!--{/if}-->
 
 <!--{if $multipage && $page < $_G['setting']['threadmaxpages'] && $page < $_G['page_next']}-->
 <!--{eval $nxtpage = $page + 1;}-->

--- a/template/default/touch/forum/viewthread.htm
+++ b/template/default/touch/forum/viewthread.htm
@@ -425,6 +425,7 @@
 	<!--{hook/viewthread_postbottom_mobile $postcount}-->
 	<!--{eval $postcount++;}-->
 	<!--{/loop}-->
+<!--{if $_G['uid']}-->
 <div id="suggestTagsWrapper" class="p10">
     <button id="suggestTagsButton" class="button">{lang suggest_tags}</button>
     <div id="suggestTagsInputArea" style="display:none">
@@ -435,6 +436,7 @@
         <button id="cancelSuggestTags" class="button">{lang cancel}</button>
     </div>
 </div>
+<!--{/if}-->
 </div>
 <script src="kk/zdy3.js?{VERHASH}"></script>
 $multipage


### PR DESCRIPTION
## Summary
- restrict tag suggestion forms to logged-in users

------
https://chatgpt.com/codex/tasks/task_e_6858366245d4832897dcfb16b89591e0