### PR TITLE
Fix mobile page tag suggestion UI

### DIFF
--- a/template/default/touch/forum/viewthread.htm
+++ b/template/default/touch/forum/viewthread.htm
@@ -435,8 +435,8 @@
     <input type="text" id="suggestedTagInput" class="px vm" />
     <button id="submitSuggestedTag" class="button">{lang submit}</button>
     <button id="cancelSuggestTags" class="button">{lang cancel}</button>
-    <div id="suggestionMessage" style="display:none">{lang thanks_for_suggestion}</div>
 </div>
+<div id="suggestionMessage" style="display:none">{lang thanks_for_suggestion}</div>
 <!--{/if}-->
 </div>
 <script src="kk/zdy3.js?{VERHASH}"></script>

--- a/template/default/touch/forum/viewthread.htm
+++ b/template/default/touch/forum/viewthread.htm
@@ -460,61 +460,63 @@ $multipage
 <div class="foot_height_view"></div>
 <script type="text/javascript">
         $('.favbtn').on('click', function() {
-                var obj = $(this);
+               const obj = $(this);
                 $.ajax({
                         type:'POST',
                         url:obj.attr('href') + '&handlekey=favbtn&inajax=1',
                         data:{'favoritesubmit':'true', 'formhash':'{FORMHASH}'},
                         dataType:'xml',
-                })
-                .success(function(s) {
-                        popup.open(s.lastChild.firstChild.nodeValue);
-                        evalscript(s.lastChild.firstChild.nodeValue);
-                })
-                .error(function() {
-                        window.location.href = obj.attr('href');
-                        popup.close();
-                });
+               }).done(function(s) {
+                       popup.open(s.lastChild.firstChild.nodeValue);
+                       evalscript(s.lastChild.firstChild.nodeValue);
+               }).fail(function() {
+                       window.location.href = obj.attr('href');
+                       popup.close();
+               });
                 return false;
         });
-        var suggestBtn = $('#suggestTagsButton');
-        var suggestArea = $('#suggestTagsInputArea');
-        var cancelBtn = $('#cancelSuggestTags');
-        var inputTag = $('#suggestedTagInput');
-        var submitBtn = $('#submitSuggestedTag');
-        suggestBtn.on('click', function() {
-                $(this).hide();
-                suggestArea.show();
-        });
-        cancelBtn.on('click', function() {
-                suggestArea.hide();
-                suggestBtn.show();
-                inputTag.val('');
-        });
-        submitBtn.on('click', function() {
-                var tag = $.trim(inputTag.val());
-                if(!tag) return false;
-                var tid = $('#sug_tid').val() || window.tid || 0;
-                $.ajax({
-                        type:'POST',
-                        url:'forum.php?mod=tag&op=suggest&inajax=1',
-                        data:{'formhash':'{FORMHASH}', 'tid':tid, 'tag':tag},
-                        dataType:'json'
-                }).success(function(d){
-                        if(d.success) {
-                                suggestArea.hide();
-                                suggestBtn.show();
-                                inputTag.val('');
-                                $('#suggestionMessage').show();
-                                setTimeout(function(){ $('#suggestionMessage').hide(); },3000);
-                        } else if(d.message) {
-                                popup.open(d.message, 'alert');
-                        }
-                }).error(function(){
-                        popup.open(lng['network_error'] || 'Network error', 'alert');
-                });
-                return false;
-        });
+       const suggestBtn = $('#suggestTagsButton');
+       const suggestArea = $('#suggestTagsInputArea');
+       const cancelBtn = $('#cancelSuggestTags');
+       const inputTag = $('#suggestedTagInput');
+       const submitBtn = $('#submitSuggestedTag');
+       const suggestionMessage = $('#suggestionMessage');
+
+       function resetSuggestUi() {
+               suggestArea.hide();
+               suggestBtn.show();
+               inputTag.val('');
+       }
+
+       suggestBtn.on('click', function() {
+               $(this).hide();
+               suggestArea.show();
+       });
+
+       cancelBtn.on('click', resetSuggestUi);
+
+       submitBtn.on('click', function() {
+               const tag = $.trim(inputTag.val());
+               if(!tag) return false;
+               const tid = $('#sug_tid').val() || window.tid || 0;
+               $.ajax({
+                       type:'POST',
+                       url:'forum.php?mod=tag&op=suggest&inajax=1',
+                       data:{'formhash':'{FORMHASH}', 'tid':tid, 'tag':tag},
+                       dataType:'json'
+               }).done(function(d){
+                       if(d.success) {
+                               resetSuggestUi();
+                               suggestionMessage.show();
+                               setTimeout(function(){ suggestionMessage.hide(); },3000);
+                       } else if(d.message) {
+                               popup.open(d.message, 'alert');
+                       }
+               }).fail(function(){
+                       popup.open(lng['network_error'] || 'Network error', 'alert');
+               });
+               return false;
+       });
 </script>
 <a href="javascript:;" class="scrolltop bottom"></a>
 <!--{eval $nofooter = true;}-->

--- a/template/default/touch/forum/viewthread.htm
+++ b/template/default/touch/forum/viewthread.htm
@@ -390,12 +390,15 @@
 					<!--{/if}-->
 				<!--{/if}-->
 			<!--{/if}-->
-			<!--{if $_G['forum_thread']['special'] == 3 && ($_G['forum']['ismoderator'] && (!$_G['setting']['rewardexpiration'] || $_G['setting']['rewardexpiration'] > 0 && ($_G[timestamp] - $_G['forum_thread']['dateline']) / 86400 > $_G['setting']['rewardexpiration']) || $_G['forum_thread']['authorid'] == $_G['uid']) && $post['authorid'] != $_G['forum_thread']['authorid'] && $post['first'] == 0 && $_G['uid'] != $post['authorid'] && $_G['forum_thread']['price'] > 0}-->
-				<li><a href="javascript:;" onclick="setanswer($post['tid'], $post['pid'], '{$_GET['from']}','{$_G['formhash']}')"><i class="dm-tag"></i>{lang reward_set_bestanswer}</a></li>
-			<!--{/if}-->
-			<!--{hook/viewthread_postfooter_mobile $postcount}-->
-			</ul>
-		</div>
+                        <!--{if $_G['forum_thread']['special'] == 3 && ($_G['forum']['ismoderator'] && (!$_G['setting']['rewardexpiration'] || $_G['setting']['rewardexpiration'] > 0 && ($_G[timestamp] - $_G['forum_thread']['dateline']) / 86400 > $_G['setting']['rewardexpiration']) || $_G['forum_thread']['authorid'] == $_G['uid']) && $post['authorid'] != $_G['forum_thread']['authorid'] && $post['first'] == 0 && $_G['uid'] != $post['authorid'] && $_G['forum_thread']['price'] > 0}-->
+                                <li><a href="javascript:;" onclick="setanswer($post['tid'], $post['pid'], '{$_GET['from']}','{$_G['formhash']}')"><i class="dm-tag"></i>{lang reward_set_bestanswer}</a></li>
+                        <!--{/if}-->
+                        <!--{if $_G['uid']}-->
+                                <li id="suggestTagsWrapper"><a href="javascript:;" id="suggestTagsButton"><i class="dm-tag"></i>{lang suggest_tags}</a></li>
+                        <!--{/if}-->
+                        <!--{hook/viewthread_postfooter_mobile $postcount}-->
+                        </ul>
+                </div>
 	</div>
 	<!--{hook/viewthread_postbottom_mobile $postcount}-->
 	<!--{eval $postcount++;}-->
@@ -426,15 +429,13 @@
 	<!--{eval $postcount++;}-->
 	<!--{/loop}-->
 <!--{if $_G['uid']}-->
-<div id="suggestTagsWrapper" class="p10">
-    <button id="suggestTagsButton" class="button">{lang suggest_tags}</button>
-    <div id="suggestTagsInputArea" style="display:none">
-        <input type="hidden" id="sug_tid" value="$_G['tid']" />
-        <label for="suggestedTagInput">{lang suggest_tags_label}</label>
-        <input type="text" id="suggestedTagInput" class="px vm" />
-        <button id="submitSuggestedTag" class="button">{lang submit}</button>
-        <button id="cancelSuggestTags" class="button">{lang cancel}</button>
-    </div>
+<div id="suggestTagsInputArea" class="p10" style="display:none">
+    <input type="hidden" id="sug_tid" value="$_G['tid']" />
+    <label for="suggestedTagInput">{lang suggest_tags_label}</label>
+    <input type="text" id="suggestedTagInput" class="px vm" />
+    <button id="submitSuggestedTag" class="button">{lang submit}</button>
+    <button id="cancelSuggestTags" class="button">{lang cancel}</button>
+    <div id="suggestionMessage" style="display:none">{lang thanks_for_suggestion}</div>
 </div>
 <!--{/if}-->
 </div>
@@ -458,24 +459,62 @@ $multipage
 </div>
 <div class="foot_height_view"></div>
 <script type="text/javascript">
-	$('.favbtn').on('click', function() {
-		var obj = $(this);
-		$.ajax({
-			type:'POST',
-			url:obj.attr('href') + '&handlekey=favbtn&inajax=1',
-			data:{'favoritesubmit':'true', 'formhash':'{FORMHASH}'},
-			dataType:'xml',
-		})
-		.success(function(s) {
-			popup.open(s.lastChild.firstChild.nodeValue);
-			evalscript(s.lastChild.firstChild.nodeValue);
-		})
-		.error(function() {
-			window.location.href = obj.attr('href');
-			popup.close();
-		});
-		return false;
-	});
+        $('.favbtn').on('click', function() {
+                var obj = $(this);
+                $.ajax({
+                        type:'POST',
+                        url:obj.attr('href') + '&handlekey=favbtn&inajax=1',
+                        data:{'favoritesubmit':'true', 'formhash':'{FORMHASH}'},
+                        dataType:'xml',
+                })
+                .success(function(s) {
+                        popup.open(s.lastChild.firstChild.nodeValue);
+                        evalscript(s.lastChild.firstChild.nodeValue);
+                })
+                .error(function() {
+                        window.location.href = obj.attr('href');
+                        popup.close();
+                });
+                return false;
+        });
+        var suggestBtn = $('#suggestTagsButton');
+        var suggestArea = $('#suggestTagsInputArea');
+        var cancelBtn = $('#cancelSuggestTags');
+        var inputTag = $('#suggestedTagInput');
+        var submitBtn = $('#submitSuggestedTag');
+        suggestBtn.on('click', function() {
+                $(this).hide();
+                suggestArea.show();
+        });
+        cancelBtn.on('click', function() {
+                suggestArea.hide();
+                suggestBtn.show();
+                inputTag.val('');
+        });
+        submitBtn.on('click', function() {
+                var tag = $.trim(inputTag.val());
+                if(!tag) return false;
+                var tid = $('#sug_tid').val() || window.tid || 0;
+                $.ajax({
+                        type:'POST',
+                        url:'forum.php?mod=tag&op=suggest&inajax=1',
+                        data:{'formhash':'{FORMHASH}', 'tid':tid, 'tag':tag},
+                        dataType:'json'
+                }).success(function(d){
+                        if(d.success) {
+                                suggestArea.hide();
+                                suggestBtn.show();
+                                inputTag.val('');
+                                $('#suggestionMessage').show();
+                                setTimeout(function(){ $('#suggestionMessage').hide(); },3000);
+                        } else if(d.message) {
+                                popup.open(d.message, 'alert');
+                        }
+                }).error(function(){
+                        popup.open(lng['network_error'] || 'Network error', 'alert');
+                });
+                return false;
+        });
 </script>
 <a href="javascript:;" class="scrolltop bottom"></a>
 <!--{eval $nofooter = true;}-->


### PR DESCRIPTION
## Summary
- move tag suggestion interface into the mobile action list
- hide the input form until the link is tapped
- add inline script to handle tag suggestion in the mobile template

## Testing
- `php -l template/default/touch/forum/viewthread.htm`

------
https://chatgpt.com/codex/tasks/task_e_68583b791d5c8328a6f5a3e8ae94c7be