### PR TITLE
Fix tag display in mobile view

### DIFF
--- a/static/image/mobile/style.css
+++ b/static/image/mobile/style.css
@@ -1367,5 +1367,9 @@ details summary { color:blue; cursor:pointer; }
 		.tf .showmenu:hover { border-color: var(--dz-BOR-ed); }
 
 		.pll .c { margin: 0 84px 0 74px; }
-		.pll ol { margin: 5px 0 0 20px; }
-			.pll ol li { list-style-type: decimal; padding: 0; border-bottom: none; }
+.pll ol { margin: 5px 0 0 20px; }
+        .pll ol li { list-style-type: decimal; padding: 0; border-bottom: none; }
+
+/* 标签 .ptg */
+.ptg:before { content: "\f14a"; font-family: dzicon; font-size: 16px; line-height: 14px; color: #7DA0CC; }
+    .ptg a { color: {HIGHLIGHTLINK}; }

--- a/template/default/touch/forum/viewthread_node.htm
+++ b/template/default/touch/forum/viewthread_node.htm
@@ -95,11 +95,24 @@
 							<!--{else}-->
 								$post['message']
 							<!--{/if}-->
-						<!--{else}-->
-							$post['message']
-						<!--{/if}-->
-						
-					<!--{/if}-->
+                                                <!--{else}-->
+                                                        $post['message']
+                                                <!--{/if}-->
+
+                                        <!--{/if}-->
+
+                                        <!--{if $post['first'] && ($post['tags'] || $relatedkeywords) && $_GET['from'] != 'preview'}-->
+                                                <div class="ptg mbm mtn">
+                                                        <!--{if $post['tags']}-->
+                                                                <!--{eval $tagi = 0;}-->
+                                                                <!--{loop $post['tags'] $var}-->
+                                                                        <!--{if $tagi}-->, <!--{/if}--><a title="$var[1]" href="misc.php?mod=tag&id=$var[0]&name=<!--{echo rawurlencode($var[1])}-->">$var[1]</a>
+                                                                        <!--{eval $tagi++;}-->
+                                                                <!--{/loop}-->
+                                                        <!--{/if}-->
+                                                        <!--{if $relatedkeywords}--><span>$relatedkeywords</span><!--{/if}-->
+                                                </div>
+                                        <!--{/if}-->
 			</div>
 			<!--{if $_G['setting']['mobile']['mobilesimpletype'] == 0}-->
 			<!--{if $post['attachment']}-->


### PR DESCRIPTION
## Summary
- show thread tags on mobile viewthread page
- add missing tag styling for mobile theme

## Testing
- `php -d detect_unicode=0 -d short_open_tag=On tests/check_discuz_login.php`


------
https://chatgpt.com/codex/tasks/task_e_6858df23b04c83289c57ce3809cd17f2