### PR TITLE
Fix tag suggestion popup in mobile

### DIFF
--- a/source/module/forum/forum_tag.php
+++ b/source/module/forum/forum_tag.php
@@ -12,7 +12,7 @@ if(!defined('IN_DISCUZ')) {
 }
 
 global $_G;
-$op = in_array($_GET['op'], array('search','match', 'manage', 'set', 'suggest')) ? $_GET['op'] : '';
+$op = in_array($_GET['op'], array('search','match', 'manage', 'set', 'suggest', 'suggestform')) ? $_GET['op'] : '';
 $taglist = array();
 $thread = & $_G['thread'];
 
@@ -133,6 +133,12 @@ if($op == 'search') {
                 echo json_encode(array('success' => false, 'message' => lang('forum/template', 'input_invalid')));
         }
         exit;
+} elseif($op == 'suggestform') {
+       if(!$_G['uid']) {
+               showmessage('to_login');
+       }
+       include template('forum/tag_suggest');
+       exit;
 }
 
 include_once template("forum/tag");

--- a/static/image/mobile/style.css
+++ b/static/image/mobile/style.css
@@ -1367,5 +1367,9 @@ details summary { color:blue; cursor:pointer; }
 		.tf .showmenu:hover { border-color: var(--dz-BOR-ed); }
 
 		.pll .c { margin: 0 84px 0 74px; }
-		.pll ol { margin: 5px 0 0 20px; }
-			.pll ol li { list-style-type: decimal; padding: 0; border-bottom: none; }
+.pll ol { margin: 5px 0 0 20px; }
+        .pll ol li { list-style-type: decimal; padding: 0; border-bottom: none; }
+
+/* 标签 .ptg */
+.ptg:before { content: "\f14a"; font-family: dzicon; font-size: 16px; line-height: 14px; color: #7DA0CC; }
+    .ptg a { color: {HIGHLIGHTLINK}; }

--- a/template/default/touch/forum/tag_suggest.htm
+++ b/template/default/touch/forum/tag_suggest.htm
@@ -1,0 +1,35 @@
+<!--{template common/header}-->
+<div class="tip loginbox loginpop p5" id="floatlayout_suggesttags">
+    <h2 class="log_tit"><a href="javascript:;" onclick="popup.close();"><span class="icon_close y">&nbsp;</span></a>{lang suggest_tags}</h2>
+    <div class="p10">
+        <input type="hidden" id="sug_tid" value="$_G['tid']" />
+        <label for="suggest_tag_input">{lang suggest_tags_label}</label>
+        <input type="text" id="suggest_tag_input" class="px vm" />
+        <button id="submitSuggestedTag" class="pn pnc"><span>{lang submit}</span></button>
+    </div>
+</div>
+<script type="text/javascript" reload="1">
+var inputTag = $('#suggest_tag_input');
+$('#submitSuggestedTag').on('click', function(){
+    var tag = inputTag.val().trim();
+    if(!tag) return false;
+    $.ajax({
+        type:'POST',
+        url:'forum.php?mod=tag&op=suggest&inajax=1',
+        data:{'formhash':'{FORMHASH}','tid':$('#sug_tid').val(),'tag':tag},
+        dataType:'json'
+    }).done(function(d){
+        if(d.success){
+            popup.open(lng['thanks_for_suggestion']);
+            setTimeout(function(){popup.close();},1500);
+        }else if(d.message){
+            popup.open(d.message, 'alert');
+        }
+    }).fail(function(){
+        popup.open(lng['network_error'], 'alert');
+    });
+    return false;
+});
+getID('suggest_tag_input').focus();
+</script>
+<!--{template common/footer}-->

--- a/template/default/touch/forum/viewthread.htm
+++ b/template/default/touch/forum/viewthread.htm
@@ -250,9 +250,21 @@
 					<!--{else}-->
 						$post['message']
 					<!--{/if}-->
-				<!--{/if}-->
-			</div>
-			<!--{if ($_G['setting']['mobile']['mobilesimpletype'] == 0) && (!$needhiddenreply)}-->
+                                <!--{/if}-->
+                        </div>
+                        <!--{if $post['first'] && (!empty($post['tags']) || $relatedkeywords) && $_GET['from'] != 'preview'}-->
+                                <div class="ptg mbm mtn">
+                                        <!--{if !empty($post['tags'])}-->
+                                                <!--{eval $tagi = 0;}-->
+                                                <!--{loop $post['tags'] $var}-->
+                                                        <!--{if $tagi}-->, <!--{/if}--><a title="$var[1]" href="misc.php?mod=tag&id=$var[0]&name=<!--{echo rawurlencode($var[1])}-->">$var[1]</a>
+                                                        <!--{eval $tagi++;}-->
+                                                <!--{/loop}-->
+                                        <!--{/if}-->
+                                        <!--{if $relatedkeywords}--><span>$relatedkeywords</span><!--{/if}-->
+                                </div>
+                        <!--{/if}-->
+                       <!--{if ($_G['setting']['mobile']['mobilesimpletype'] == 0) && (!$needhiddenreply)}-->
 			<!--{if $post['attachment']}-->
 				<div class="quote">
 				{lang attachment}: <em><!--{if $_G['uid']}-->{lang attach_nopermission}<!--{else}-->{lang attach_nopermission_login}<!--{/if}--></em>
@@ -394,7 +406,7 @@
                                 <li><a href="javascript:;" onclick="setanswer($post['tid'], $post['pid'], '{$_GET['from']}','{$_G['formhash']}')"><i class="dm-tag"></i>{lang reward_set_bestanswer}</a></li>
                         <!--{/if}-->
                         <!--{if $_G['uid'] && $post['first']}-->
-                                <li id="suggestTagsWrapper"><a href="javascript:;" id="suggestTagsButton"><i class="dm-tag"></i>{lang suggest_tags}</a></li>
+                                <li id="suggestTagsWrapper"><a href="forum.php?mod=tag&op=suggestform&tid={$_G['tid']}&mobile=2" id="suggestTagsButton" class="dialog"><i class="dm-tag"></i>{lang suggest_tags}</a></li>
                         <!--{/if}-->
                         <!--{hook/viewthread_postfooter_mobile $postcount}-->
                         </ul>
@@ -428,16 +440,6 @@
 	<!--{hook/viewthread_postbottom_mobile $postcount}-->
 	<!--{eval $postcount++;}-->
 	<!--{/loop}-->
-<!--{if $_G['uid']}-->
-<div id="suggestTagsInputArea" class="p10" style="display:none">
-    <input type="hidden" id="sug_tid" value="$_G['tid']" />
-    <label for="suggestedTagInput">{lang suggest_tags_label}</label>
-    <input type="text" id="suggestedTagInput" class="px vm" />
-    <button id="submitSuggestedTag" class="button">{lang submit}</button>
-    <button id="cancelSuggestTags" class="button">{lang cancel}</button>
-</div>
-<div id="suggestionMessage" style="display:none">{lang thanks_for_suggestion}</div>
-<!--{/if}-->
 </div>
 <script src="kk/zdy3.js?{VERHASH}"></script>
 $multipage
@@ -475,48 +477,6 @@ $multipage
                });
                 return false;
         });
-       const suggestBtn = $('#suggestTagsButton');
-       const suggestArea = $('#suggestTagsInputArea');
-       const cancelBtn = $('#cancelSuggestTags');
-       const inputTag = $('#suggestedTagInput');
-       const submitBtn = $('#submitSuggestedTag');
-       const suggestionMessage = $('#suggestionMessage');
-
-       function resetSuggestUi() {
-               suggestArea.hide();
-               suggestBtn.show();
-               inputTag.val('');
-       }
-
-       suggestBtn.on('click', function() {
-               $(this).hide();
-               suggestArea.show();
-       });
-
-       cancelBtn.on('click', resetSuggestUi);
-
-       submitBtn.on('click', function() {
-               const tag = inputTag.val().trim();
-               if(!tag) return false;
-               const tid = $('#sug_tid').val() || window.tid || 0;
-               $.ajax({
-                       type:'POST',
-                       url:'forum.php?mod=tag&op=suggest&inajax=1',
-                       data:{'formhash':'{FORMHASH}', 'tid':tid, 'tag':tag},
-                       dataType:'json'
-               }).done(function(d){
-                       if(d.success) {
-                               resetSuggestUi();
-                               suggestionMessage.show();
-                               setTimeout(function(){ suggestionMessage.hide(); },3000);
-                       } else if(d.message) {
-                               popup.open(d.message, 'alert');
-                       }
-               }).fail(function(){
-                       popup.open(lng['network_error'], 'alert');
-               });
-               return false;
-       });
 </script>
 <a href="javascript:;" class="scrolltop bottom"></a>
 <!--{eval $nofooter = true;}-->


### PR DESCRIPTION
## Summary
- add `suggestform` handler in `forum_tag.php`
- create mobile template `tag_suggest.htm`
- open tag suggestion dialog from mobile thread view
- remove old inline tag suggestion script

## Testing
- `php -d detect_unicode=0 -d short_open_tag=On tests/check_discuz_login.php`
- `curl -s "127.0.0.1/forum.php?mod=viewthread&tid=13812&mobile=2" | grep -n "ptg" | head`
- `curl -s "127.0.0.1/forum.php?mod=tag&op=suggestform&tid=13812&mobile=2&inajax=1" | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6858df23b04c83289c57ce3809cd17f2