### PR TITLE
Update timezone handling in chat history

### DIFF
--- a/chat/php/history.php
+++ b/chat/php/history.php
@@ -20,7 +20,7 @@ if ($count_result) {
     $total_rows = $count_result->fetch_assoc()['total'];
 }
 
-$sql = "SELECT DATE_FORMAT(time, '%Y-%m-%dT%TZ') as ISO8601, uid, author, message FROM chat ORDER BY time DESC LIMIT ? OFFSET ?";
+$sql = "SELECT DATE_FORMAT( CONVERT_TZ(`timestamp`, @@session.time_zone, '+00:00'), '%Y-%m-%dT%TZ') as ISO8601, uid, author, message FROM chat ORDER BY time DESC LIMIT ? OFFSET ?";
 $stmt = $conn->prepare($sql);
 $stmt->bind_param("ii", $limit, $offset);
 $stmt->execute();


### PR DESCRIPTION
## Summary
- convert chat timestamps to UTC before formatting ISO8601 output

## Testing
- `php -l chat/php/history.php`
- `php -l chat/php/delete.php`
- `php -l chat/php/chat.php`
- `php tests/check_discuz_login.php`

------
https://chatgpt.com/codex/tasks/task_e_685e409bbd6883288bc70685b9402ecd