### PR TITLE
Fix timezone query for existing time column

### DIFF
--- a/chat/php/history.php
+++ b/chat/php/history.php
@@ -20,8 +20,14 @@ if ($count_result) {
     $total_rows = $count_result->fetch_assoc()['total'];
 }
 
-$sql = "SELECT DATE_FORMAT(time, '%Y-%m-%dT%TZ') as ISO8601, uid, author, message FROM chat ORDER BY time DESC LIMIT ? OFFSET ?";
+$sql = "SELECT DATE_FORMAT(CONVERT_TZ(time, @@session.time_zone, '+00:00'), '%Y-%m-%dT%TZ') as ISO8601, uid, author, message FROM chat ORDER BY time DESC LIMIT ? OFFSET ?";
 $stmt = $conn->prepare($sql);
+if ($stmt === false) {
+    error_log('Prepare failed: ' . $conn->error);
+    echo json_encode(['error' => 'Database query failed']);
+    $conn->close();
+    exit;
+}
 $stmt->bind_param("ii", $limit, $offset);
 $stmt->execute();
 $result = $stmt->get_result();


### PR DESCRIPTION
## Summary
- correct chat history timestamp formatting to use existing `time` field
- keep prepare error check

## Testing
- `php -l chat/php/history.php`
- `php -l chat/php/delete.php`
- `php -l chat/php/chat.php`
- `php tests/check_discuz_login.php`


------
https://chatgpt.com/codex/tasks/task_e_685e409bbd6883288bc70685b9402ecd