### PR TITLE
Remove unused ajax helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,8 @@ Shows a configurable menu. The object `v` can include keys such as `ctrlid`, `sh
 ### `setMenuPosition(showid, menuid, pos)`
 Positions the menu element `menuid` relative to `showid` using the two-digit `pos` code denoting anchor and direction.
 
+### `_ajaxget(url, showid, waitid, loading, display, recall)`
+### `_ajaxpost(formid, showid, waitid, showidclass, submitbtn, recall)`
+Low level helpers from `static/js/ajax.js` that fetch new content via GET or POST. After receiving HTML, the response is processed by `evalscript()` which in turn uses `appendscript()` from `static/js/common.js` to inject any `<script>` blocks so dynamic features remain functional. These functions are invoked by the global `ajaxget()` and `ajaxpost()` wrappers defined in `static/js/common.js`.
+
+

--- a/static/js/ajax.js
+++ b/static/js/ajax.js
@@ -177,39 +177,6 @@ function _ajaxmenu(ctrlObj, timeout, cache, duration, pos, recall, idclass, cont
 	doane();
 }
 
-function _appendscript(src, text, reload, charset) {
-	var id = hash(src + text);
-	if(!reload && in_array(id, evalscripts)) return;
-	if(reload && $(id)) {
-		$(id).parentNode.removeChild($(id));
-	}
-
-	evalscripts.push(id);
-	var scriptNode = document.createElement("script");
-	scriptNode.type = "text/javascript";
-	scriptNode.id = id;
-	scriptNode.charset = charset ? charset : (BROWSER.firefox ? document.characterSet : document.charset);
-	try {
-		if(src) {
-			scriptNode.src = src;
-			scriptNode.onloadDone = false;
-			scriptNode.onload = function () {
-				scriptNode.onloadDone = true;
-				JSLOADED[src] = 1;
-			};
-			scriptNode.onreadystatechange = function () {
-				if((scriptNode.readyState == 'loaded' || scriptNode.readyState == 'complete') && !scriptNode.onloadDone) {
-					scriptNode.onloadDone = true;
-					JSLOADED[src] = 1;
-				}
-			};
-		} else if(text){
-			scriptNode.text = text;
-		}
-		document.getElementsByTagName('head')[0].appendChild(scriptNode);
-	} catch(e) {}
-}
-
 function _ajaxupdateevents(obj, tagName) {
 	tagName = tagName ? tagName : 'A';
 	var objs = obj.getElementsByTagName(tagName);

--- a/template/default/forum/tag_input.htm
+++ b/template/default/forum/tag_input.htm
@@ -21,7 +21,7 @@ color: red;
 <input name="tags" type="hidden" id="tags" value="<!--{echo $tags or $postinfo['tag']}-->">
 <input id="keyword-input" size="30" placeholder="{lang input_a_new_tag_press_enter_submit}" list="tag-suggestions">
 <datalist id="tag-suggestions"></datalist>
-<script>
+<script reload="1">
     $('keyword-input').addEventListener('input', async function() {
         const query = this.value.trim();
         if (mb_strlen(query) < 2) return; // Only fetch suggestions for queries longer than 1 character
@@ -41,7 +41,7 @@ color: red;
         }
     });
 </script>
-<script>
+<script reload="1">
 {
     const chipContainer = document.getElementById('chip-container');
     const keywords = $('tags').value ? $('tags').value.split(',') : [];


### PR DESCRIPTION
## Summary
- delete `_appendscript` from `static/js/ajax.js`
- update README to note that AJAX helpers rely on callbacks using `appendscript()` from `common.js`
- clarify that global `ajaxget()`/`ajaxpost()` wrappers invoke these helpers
- reload scripts in tag_input template so events persist after AJAX refresh

------
https://chatgpt.com/codex/tasks/task_e_686364b7a0ec83289eaf80e66e3ac972