### PR TITLE
Remove unused ajax helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,8 @@ Shows a configurable menu. The object `v` can include keys such as `ctrlid`, `sh
 ### `setMenuPosition(showid, menuid, pos)`
 Positions the menu element `menuid` relative to `showid` using the two-digit `pos` code denoting anchor and direction.
 
+### `_ajaxget(url, showid, waitid, loading, display, recall)`
+### `_ajaxpost(formid, showid, waitid, showidclass, submitbtn, recall)`
+Low level helpers from `static/js/ajax.js` that fetch new content via GET or POST. After receiving HTML, the response is processed by `evalscript()` which in turn uses `appendscript()` from `static/js/common.js` to inject any `<script>` blocks so dynamic features remain functional. These functions are invoked by the global `ajaxget()` and `ajaxpost()` wrappers defined in `static/js/common.js`.
+
+

--- a/static/js/ajax.js
+++ b/static/js/ajax.js
@@ -6,19 +6,19 @@
 */
 
 function _ajaxget(url, showid, waitid, loading, display, recall) {
-	waitid = typeof waitid == 'undefined' || waitid === null ? showid : waitid;
-	var x = new Ajax();
-	x.setLoading(loading);
-	x.setWaitId(waitid);
-	x.display = typeof display == 'undefined' || display == null ? '' : display;
-	x.showId = $(showid);
+       waitid = typeof waitid == 'undefined' || waitid === null ? showid : waitid;
+       var x = new Ajax();
+       x.setLoading(loading);
+       x.setWaitId(waitid);
+       x.display = typeof display == 'undefined' || display == null ? '' : display;
+       x.showId = $(showid);
 
 	if(url.substr(strlen(url) - 1) == '#') {
 		url = url.substr(0, strlen(url) - 1);
 		x.autogoto = 1;
 	}
 
-	var url = url + '&inajax=1&ajaxtarget=' + showid;
+       url = url + '&inajax=1&ajaxtarget=' + showid;
 	x.get(url, function(s, x) {
 		var evaled = false;
 		if(s.indexOf('ajaxerror') != -1) {
@@ -45,8 +45,8 @@ function _ajaxget(url, showid, waitid, loading, display, recall) {
 }
 
 function _ajaxpost(formid, showid, waitid, showidclass, submitbtn, recall) {
-	var waitid = typeof waitid == 'undefined' || waitid === null ? showid : (waitid !== '' ? waitid : '');
-	var showidclass = !showidclass ? '' : showidclass;
+       waitid = typeof waitid == 'undefined' || waitid === null ? showid : (waitid !== '' ? waitid : '');
+       showidclass = !showidclass ? '' : showidclass;
 	var ajaxframeid = 'ajaxframe';
 	var ajaxframe = $(ajaxframeid);
 	var curform = $(formid);
@@ -63,7 +63,7 @@ function _ajaxpost(formid, showid, waitid, showidclass, submitbtn, recall) {
 			try {
 				s = $(ajaxframeid).contentWindow.document.documentElement.firstChild.nodeValue;
 			} catch(e) {
-                               s = lng['int_error'];
+                               s = lng.int_error;
 			}
 		}
                if(s && s.indexOf('ajaxerror') != -1) {
@@ -130,17 +130,19 @@ function _ajaxpost(formid, showid, waitid, showidclass, submitbtn, recall) {
 }
 
 function _ajaxmenu(ctrlObj, timeout, cache, duration, pos, recall, idclass, contentclass) {
-	if(!ctrlObj.getAttribute('mid')) {
-		var ctrlid = ctrlObj.id;
-		if(!ctrlid) {
-			ctrlObj.id = 'ajaxid_' + Math.random();
-		}
-	} else {
-		var ctrlid = ctrlObj.getAttribute('mid');
-		if(!ctrlObj.id) {
-			ctrlObj.id = 'ajaxid_' + Math.random();
-		}
-	}
+       var ctrlid;
+       if(!ctrlObj.getAttribute('mid')) {
+               ctrlid = ctrlObj.id;
+               if(!ctrlid) {
+                       ctrlObj.id = 'ajaxid_' + Math.random();
+                       ctrlid = ctrlObj.id;
+               }
+       } else {
+               ctrlid = ctrlObj.getAttribute('mid');
+               if(!ctrlObj.id) {
+                       ctrlObj.id = 'ajaxid_' + Math.random();
+               }
+       }
 	var menuid = ctrlid + '_menu';
 	var menu = $(menuid);
 	if(isUndefined(timeout)) timeout = 3000;
@@ -171,52 +173,19 @@ function _ajaxmenu(ctrlObj, timeout, cache, duration, pos, recall, idclass, cont
 	menu.className = idclass;
 	menu.innerHTML = '<div class="' + contentclass + '" id="' + menuid + '_content"></div>';
 	$('append_parent').appendChild(menu);
-	var url = (!isUndefined(ctrlObj.attributes['shref']) ? ctrlObj.attributes['shref'].value : (!isUndefined(ctrlObj.href) ? ctrlObj.href : ctrlObj.attributes['href'].value));
+       var url = (!isUndefined(ctrlObj.attributes.shref) ? ctrlObj.attributes.shref.value : (!isUndefined(ctrlObj.href) ? ctrlObj.href : ctrlObj.attributes.href.value));
 	url += (url.indexOf('?') != -1 ? '&' :'?') + 'ajaxmenu=1';
 	ajaxget(url, menuid + '_content', 'ajaxwaitid', '', '', func);
 	doane();
 }
 
-function _appendscript(src, text, reload, charset) {
-	var id = hash(src + text);
-	if(!reload && in_array(id, evalscripts)) return;
-	if(reload && $(id)) {
-		$(id).parentNode.removeChild($(id));
-	}
-
-	evalscripts.push(id);
-	var scriptNode = document.createElement("script");
-	scriptNode.type = "text/javascript";
-	scriptNode.id = id;
-	scriptNode.charset = charset ? charset : (BROWSER.firefox ? document.characterSet : document.charset);
-	try {
-		if(src) {
-			scriptNode.src = src;
-			scriptNode.onloadDone = false;
-			scriptNode.onload = function () {
-				scriptNode.onloadDone = true;
-				JSLOADED[src] = 1;
-			};
-			scriptNode.onreadystatechange = function () {
-				if((scriptNode.readyState == 'loaded' || scriptNode.readyState == 'complete') && !scriptNode.onloadDone) {
-					scriptNode.onloadDone = true;
-					JSLOADED[src] = 1;
-				}
-			};
-		} else if(text){
-			scriptNode.text = text;
-		}
-		document.getElementsByTagName('head')[0].appendChild(scriptNode);
-	} catch(e) {}
-}
-
 function _ajaxupdateevents(obj, tagName) {
-	tagName = tagName ? tagName : 'A';
-	var objs = obj.getElementsByTagName(tagName);
-	for(k in objs) {
-		var o = objs[k];
-		ajaxupdateevent(o);
-	}
+       tagName = tagName ? tagName : 'A';
+       var objs = obj.getElementsByTagName(tagName);
+       for(var k in objs) {
+               var o = objs[k];
+               ajaxupdateevent(o);
+       }
 }
 
 function _ajaxupdateevent(o) {
@@ -245,16 +214,16 @@ function _ajaxinnerhtml(showid, s) {
 		div1.id = showid.id+'_div';
 		div1.innerHTML = '<table><tbody id="'+showid.id+'_tbody">'+s+'</tbody></table>';
 		$('append_parent').appendChild(div1);
-		var trs = div1.getElementsByTagName('TR');
-		var l = trs.length;
-		for(var i=0; i<l; i++) {
-			showid.appendChild(trs[0]);
-		}
-		var inputs = div1.getElementsByTagName('INPUT');
-		var l = inputs.length;
-		for(var i=0; i<l; i++) {
-			showid.appendChild(inputs[0]);
-		}
+               var trs = div1.getElementsByTagName('TR');
+               var trsLen = trs.length;
+               for(var i = 0; i < trsLen; i++) {
+                       showid.appendChild(trs[0]);
+               }
+               var inputs = div1.getElementsByTagName('INPUT');
+               var inputsLen = inputs.length;
+               for(var j = 0; j < inputsLen; j++) {
+                       showid.appendChild(inputs[0]);
+               }
 		div1.parentNode.removeChild(div1);
 	}
 }

--- a/template/default/forum/tag_input.htm
+++ b/template/default/forum/tag_input.htm
@@ -21,7 +21,7 @@ color: red;
 <input name="tags" type="hidden" id="tags" value="<!--{echo $tags or $postinfo['tag']}-->">
 <input id="keyword-input" size="30" placeholder="{lang input_a_new_tag_press_enter_submit}" list="tag-suggestions">
 <datalist id="tag-suggestions"></datalist>
-<script>
+<script reload="1">
     $('keyword-input').addEventListener('input', async function() {
         const query = this.value.trim();
         if (mb_strlen(query) < 2) return; // Only fetch suggestions for queries longer than 1 character
@@ -41,7 +41,7 @@ color: red;
         }
     });
 </script>
-<script>
+<script reload="1">
 {
     const chipContainer = document.getElementById('chip-container');
     const keywords = $('tags').value ? $('tags').value.split(',') : [];


### PR DESCRIPTION
## Summary
- delete `_appendscript` from `static/js/ajax.js`
- update README to note that AJAX helpers rely on callbacks using `appendscript()` from `common.js`
- clarify that global `ajaxget()`/`ajaxpost()` wrappers invoke these helpers
- reload scripts in tag_input template so events persist after AJAX refresh
- resolve jshint warnings in `ajax.js`

## Testing
- `php -l tests/check_discuz_login.php`
- `npx jshint static/js/ajax.js`


------
https://chatgpt.com/codex/tasks/task_e_686364b7a0ec83289eaf80e66e3ac972