### PR TITLE
Fix leftover flash cleanup issues

### DIFF
--- a/source/function/function_attachment.php
+++ b/source/function/function_attachment.php
@@ -41,9 +41,8 @@ function attachtype($type, $returnval = 'html') {
 			$typeid = 13;
 		} elseif(preg_match("/pdf|^pdf\t/", $type)) {
 			$typeid = 12;
-		} elseif(preg_match("/image|^(jpg|gif|png|bmp|webp|svg)\t/", $type)) {
-			$typeid = 11;
-                       $typeid = 10;
+               } elseif(preg_match("/image|^(jpg|gif|png|bmp|webp|svg)\t/", $type)) {
+                        $typeid = 11;
 		} elseif(preg_match("/audio|video|^(wav|mid|mp3|m3u|wma|asf|asx|vqf|mpg|mpeg|avi|wmv|mov|mp4|m4a|m4v|3gp|ogv|ogg|webm|weba|aac|flac)\t/", $type)) {
 			$typeid = 9;
 		} elseif(preg_match("/real|^(ra|rm|rv)\t/", $type)) {

--- a/template/default/forum/editor_menu_forum.htm
+++ b/template/default/forum/editor_menu_forum.htm
@@ -129,9 +129,8 @@
 				<div id="imgattachlist"></div>
 				<div id="unusedimgattachlist"></div>
 
-				<!--{if $allowuploadtoday}-->
-
-
+                               <!--{if $allowuploadtoday}-->
+                                       <div class="fieldset flash" id="imgUploadProgress"></div>
 				<script type="text/javascript">
 					function createNewAlbum() {
 						var inputObj = $('newalbum');
@@ -299,8 +298,9 @@
 				<div id="attachlist"></div>
 				<div id="unusedattachlist"></div>
 
-				<!--{if $allowuploadtoday}-->
-				<!--{/if}-->
+                               <!--{if $allowuploadtoday}-->
+                                       <div class="fieldset flash" id="fsUploadProgress"></div>
+                               <!--{/if}-->
 
 			</div>
 			<div class="notice upnf">


### PR DESCRIPTION
### Summary

Removed a stray $typeid = 10 assignment to clean up the attachment type checks

Restored upload progress containers in the forum editor menu so uploads show progress again

### Testing

✅ find . -name "*.php" -print0 | xargs -0 -n1 php -l > /dev/null 2> /tmp/php_errors.log

✅ wc -l /tmp/php_errors.log returned 0 lines

✅ grep -Ril "flash" --exclude-dir=.git --exclude-dir=vendor | head

✅ grep -Ril "AC_FL" --exclude-dir=.git --exclude-dir=vendor | head produced no output

✅ grep -Ril "macromedia" --exclude-dir=.git --exclude-dir=vendor | head produced no output

✅ grep -Ril "shockwave" --exclude-dir=.git --exclude-dir=vendor | head produced no output

✅ grep -Ril "swf" --exclude-dir=.git --exclude-dir=vendor | head

✅ grep -Ril "flv" --exclude-dir=.git --exclude-dir=vendor | head