### PR TITLE
Fix PHP 8.2 string interpolation warning

### DIFF
--- a/source/function/function_post.php
+++ b/source/function/function_post.php
@@ -455,7 +455,7 @@ function updateforumcount($fid) {
 	//$thread['subject'] = addslashes($thread['subject']);
 	$thread['lastposter'] = $thread['author'] ? addslashes($thread['lastposter']) : lang('forum/misc', 'anonymous');
 	$tid = $thread['closed'] > 1 ? $thread['closed'] : $thread['tid'];
-	$setarr = array('posts' => $posts, 'threads' => $threads, 'lastpost' => "$tid\t{$thread['subject']}\t{$thread['lastpost']}\t${thread['lastposter']}");
+$setarr = array('posts' => $posts, 'threads' => $threads, 'lastpost' => "$tid\t{$thread['subject']}\t{$thread['lastpost']}\t{$thread['lastposter']}");
 	C::t('forum_forum')->update($fid, $setarr);
 }
 


### PR DESCRIPTION
## Summary
- fix deprecated `${}` interpolation in `function_post.php`

## Testing
- `php -l source/function/function_post.php`

------
https://chatgpt.com/codex/tasks/task_e_68656762ec488328b625d3a81ef15d46