### PR TITLE
Restrict wiki link search to current topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ data/
 uc_server/data/
 json/users.json
 json/accesslog.json
+chat/php/config.php
+source/class/class_pusher.php

--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -28,34 +28,22 @@ class MediaWikiParsedown extends ParsedownPlus
     {
         if (preg_match('/^\[\[([^\s#\]]+)([^\s\]]*)\]\]/', $Excerpt['text'], $matches))
         {
-            $filename = $matches[1];
+            $path     = $matches[1];
             $fragment = $matches[2];
+
             $requestUriParts = explode('/', $_SERVER['REQUEST_URI']);
             end($requestUriParts);
-            $topic = urldecode(prev($requestUriParts));
-            $newPage = !file_exists('pages/' . $topic . '/' . $filename . '.php');
-            if ($newPage) { // search in all topics for the closest match
-                $closestTopic = null;
-                $shortestDistance = PHP_INT_MAX;
+            $currentTopic = urldecode(prev($requestUriParts));
 
-                foreach (glob('pages/*/' . $filename . '.php') as $filePath) {
-                    $dirName = basename(dirname($filePath));
-                    $distance = levenshtein($topic, $dirName);
-
-                    if ($distance < $shortestDistance) {
-                        $shortestDistance = $distance;
-                        $closestTopic = $dirName;
-                    }
-                }
-
-                if ($closestTopic !== null) {
-                    $topic = $closestTopic;
-                    $newPage = false;
-                }
+            if (strpos($path, '/') !== false) {
+                list($topic, $filename) = explode('/', $path, 2);
             } else {
-                $closestTopic = $topic;
+                $topic    = $currentTopic;
+                $filename = $path;
             }
-            $url = $newPage ? '/page/create?mainfilename=' . urlencode($filename) : '/page/' . $closestTopic . '/' . $filename;
+
+            $newPage = !file_exists('pages/' . $topic . '/' . $filename . '.php');
+            $url = $newPage ? '/page/create?mainfilename=' . urlencode($filename) : '/page/' . $topic . '/' . $filename;
             $Inline = array(
                 'extent' => strlen($matches[0]),
                 'element' => array(


### PR DESCRIPTION
## Summary
- refine MediaWiki link parser
- ignore chat and pusher config files

## Testing
- `php -l src/lib/DocPHT.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68668880d15483289905438afcd6668b