### PR TITLE
Update flat mode to use MediaWikiParsedown

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Deleting the JSON file removes the editable source for the page, so while the ex
 For small sites this repository also includes a very basic "flat" mode where
 each page lives as a single Markdown file under the `flat/` directory. The new
 `FlatPageModel` (see `src/model/FlatPageModel.php`) can read and write these
-files and `flat_doc.php` renders them directly using Parsedown.
+files and `flat_doc.php` renders them using the same `MediaWikiParsedown`
+parser employed by the rest of the documentation.
 
 This mode drops all advanced DocPHT features such as attachments, code blocks
 and versioning so only raw Markdown is supported.

--- a/src/model/FlatPageModel.php
+++ b/src/model/FlatPageModel.php
@@ -1,7 +1,7 @@
 <?php
 namespace DocPHT\Model;
 
-use Parsedown;
+use DocPHT\Lib\MediaWikiParsedown;
 
 class FlatPageModel
 {
@@ -39,7 +39,7 @@ class FlatPageModel
         if ($markdown === null) {
             return null;
         }
-        $Parsedown = new Parsedown();
+        $Parsedown = new MediaWikiParsedown();
         return $Parsedown->text($markdown);
     }
 }


### PR DESCRIPTION
## Summary
- switch FlatPageModel from Parsedown to MediaWikiParsedown
- update README to describe new parser

## Testing
- `php -l src/model/FlatPageModel.php`
- `php -l flat_doc.php`
- `composer validate --no-check-all --no-check-publish`
- `php tests/check_discuz_login.php`


------
https://chatgpt.com/codex/tasks/task_e_68668cd0b12c832890332c86907001aa