### PR TITLE
Remove deprecated link button block

### DIFF
--- a/public/assets/js/doc-pht.js
+++ b/public/assets/js/doc-pht.js
@@ -163,7 +163,6 @@ var all_languages = document.querySelectorAll("[id^='frm-language']");
 var all_files = document.querySelectorAll("[id^='frm-file']");
 var all_option_content = document.querySelectorAll("[id^='frm-option_content']");
 var all_name = document.querySelectorAll("[id^='frm-names']");
-var all_trg = document.querySelectorAll("[id^='frm-trgs']");
 
 var labels = document.getElementsByTagName('LABEL');
 for (var i = 0; i < labels.length; i++) {
@@ -181,42 +180,25 @@ for (var i = 0; i < all_options.length; i++) {
         all_languages[i].parentNode.parentNode.style.display = "block"; 
         all_files[i].parentNode.parentNode.style.display = "none";
         all_option_content[i].parentNode.parentNode.style.display = "block"; 
-        all_name[i].parentNode.parentNode.style.display = "none";
-        all_trg[i].parentNode.parentNode.style.display = "none"; 
-    } else if (all_options[i].value == "codeFile") {
+        all_name[i].parentNode.parentNode.style.display = "none";    } else if (all_options[i].value == "codeFile") {
         all_languages[i].parentNode.parentNode.style.display = "block";
         all_files[i].parentNode.parentNode.style.display = "block"; 
         all_option_content[i].parentNode.parentNode.style.display = "none"; 
-        all_name[i].parentNode.parentNode.style.display = "none";
-        all_trg[i].parentNode.parentNode.style.display = "none"; 
-    } else if (all_options[i].value == "markdodwnFile") {
+        all_name[i].parentNode.parentNode.style.display = "none";    } else if (all_options[i].value == "markdodwnFile") {
         all_languages[i].parentNode.parentNode.style.display = "none";
         all_files[i].parentNode.parentNode.style.display = "block"; 
         all_option_content[i].parentNode.parentNode.style.display = "none"; 
-        all_name[i].parentNode.parentNode.style.display = "none";
-        all_trg[i].parentNode.parentNode.style.display = "none"; 
-    } else if (all_options[i].value == "image") {
+        all_name[i].parentNode.parentNode.style.display = "none";    } else if (all_options[i].value == "image") {
         all_option_content[i].label.innerHTML = 'Image Name';
         all_languages[i].parentNode.parentNode.style.display = "none";
         all_files[i].parentNode.parentNode.style.display = "block"; 
         all_option_content[i].parentNode.parentNode.style.display = "block"; 
-        all_name[i].parentNode.parentNode.style.display = "none";
-        all_trg[i].parentNode.parentNode.style.display = "none"; 
-    } else if (all_options[i].value == "imageURL") {
+        all_name[i].parentNode.parentNode.style.display = "none";    } else if (all_options[i].value == "imageURL") {
         all_option_content[i].label.innerHTML = 'Image URL Link:';
         all_languages[i].parentNode.parentNode.style.display = "none";
         all_files[i].parentNode.parentNode.style.display = "none"; 
         all_option_content[i].parentNode.parentNode.style.display = "block"; 
-        all_name[i].parentNode.parentNode.style.display = "block";
-        all_trg[i].parentNode.parentNode.style.display = "none"; 
-    } else if (all_options[i].value == "linkButton") {
-        all_option_content[i].label.innerHTML = 'URL Link:';
-        all_languages[i].parentNode.parentNode.style.display = "none";
-        all_files[i].parentNode.parentNode.style.display = "none"; 
-        all_option_content[i].parentNode.parentNode.style.display = "block"; 
-        all_name[i].parentNode.parentNode.style.display = "block";
-        all_trg[i].parentNode.parentNode.style.display = "block"; 
-    } else {
+        all_name[i].parentNode.parentNode.style.display = "block";    } else {
             switch(all_options[i].value) {
                   case "title":
                     all_option_content[i].label.innerHTML = 'Title:';
@@ -239,9 +221,7 @@ for (var i = 0; i < all_options.length; i++) {
         all_languages[i].parentNode.parentNode.style.display = "none";
         all_files[i].parentNode.parentNode.style.display = "none"; 
         all_option_content[i].parentNode.parentNode.style.display = "block"; 
-        all_name[i].parentNode.parentNode.style.display = "none";
-        all_trg[i].parentNode.parentNode.style.display = "none"; 
-    }
+        all_name[i].parentNode.parentNode.style.display = "none";    }
     
 }
 
@@ -251,7 +231,6 @@ document.addEventListener("change", function(){
     var all_files = document.querySelectorAll("[id^='frm-file']");
     var all_option_content = document.querySelectorAll("[id^='frm-option_content']");
     var all_name = document.querySelectorAll("[id^='frm-names']");
-    var all_trg = document.querySelectorAll("[id^='frm-trgs']");
     
     for (var i = 0; i < all_options.length; i++) {
         if (all_options[i].value == "codeInline") {
@@ -259,48 +238,29 @@ document.addEventListener("change", function(){
             all_languages[i].parentNode.parentNode.parentNode.style.display = "block"; 
             all_files[i].parentNode.parentNode.style.display = "none";
             all_option_content[i].parentNode.parentNode.style.display = "block"; 
-            all_name[i].parentNode.parentNode.style.display = "none";
-            all_trg[i].parentNode.parentNode.style.display = "none";
-        } else if (all_options[i].value == "codeFile") {
+            all_name[i].parentNode.parentNode.style.display = "none";        } else if (all_options[i].value == "codeFile") {
             all_languages[i].parentNode.parentNode.parentNode.style.display = "block";
             all_files[i].parentNode.parentNode.style.display = "block"; 
             all_option_content[i].parentNode.parentNode.style.display = "none"; 
-            all_name[i].parentNode.parentNode.style.display = "none";
-            all_trg[i].parentNode.parentNode.style.display = "none";
-        } else if (all_options[i].value == "markdownFile") {
+            all_name[i].parentNode.parentNode.style.display = "none";        } else if (all_options[i].value == "markdownFile") {
             all_languages[i].parentNode.parentNode.parentNode.style.display = "none";
             all_files[i].parentNode.parentNode.style.display = "block"; 
             all_option_content[i].parentNode.parentNode.style.display = "none"; 
-            all_name[i].parentNode.parentNode.style.display = "none";
-            all_trg[i].parentNode.parentNode.style.display = "none";
-        } else if (all_options[i].value == "image") {
+            all_name[i].parentNode.parentNode.style.display = "none";        } else if (all_options[i].value == "image") {
             all_option_content[i].label.innerHTML = 'Image Name:';
             all_languages[i].parentNode.parentNode.parentNode.style.display = "none";
             all_files[i].parentNode.parentNode.style.display = "block"; 
             all_option_content[i].parentNode.parentNode.style.display = "block"; 
-            all_name[i].parentNode.parentNode.style.display = "none";
-            all_trg[i].parentNode.parentNode.style.display = "none";
-        } else if (all_options[i].value == "imageURL") {
+            all_name[i].parentNode.parentNode.style.display = "none";        } else if (all_options[i].value == "imageURL") {
             all_option_content[i].label.innerHTML = 'Image URL Link:';
             all_languages[i].parentNode.parentNode.parentNode.style.display = "none";
             all_files[i].parentNode.parentNode.style.display = "none"; 
             all_option_content[i].parentNode.parentNode.style.display = "block"; 
-            all_name[i].parentNode.parentNode.style.display = "block";
-            all_trg[i].parentNode.parentNode.style.display = "none";
-        } else if (all_options[i].value == "linkButton") {
-            all_option_content[i].label.innerHTML = 'URL Link:';
+            all_name[i].parentNode.parentNode.style.display = "block";        } else {
             all_languages[i].parentNode.parentNode.parentNode.style.display = "none";
             all_files[i].parentNode.parentNode.style.display = "none"; 
             all_option_content[i].parentNode.parentNode.style.display = "block"; 
-            all_name[i].parentNode.parentNode.style.display = "block";
-            all_trg[i].parentNode.parentNode.style.display = "block";
-        } else {
-            all_languages[i].parentNode.parentNode.parentNode.style.display = "none";
-            all_files[i].parentNode.parentNode.style.display = "none"; 
-            all_option_content[i].parentNode.parentNode.style.display = "block"; 
-            all_name[i].parentNode.parentNode.style.display = "none";
-            all_trg[i].parentNode.parentNode.style.display = "none";
-        }
+            all_name[i].parentNode.parentNode.style.display = "none";        }
     }
 });
 

--- a/src/forms/AddSectionForm.php
+++ b/src/forms/AddSectionForm.php
@@ -57,9 +57,6 @@ class AddSectionForm extends MakeupForm
             ->setHtmlAttribute('data-parent', 'options')
             ->setAttribute('data-autoresize');
         
-        $form->addCheckbox('trgs', T::trans('Open in New Window?'))
-            ->setHtmlAttribute('data-parent', 'options')
-            ->setAttribute('data-autoresize');
         
         $form->addProtection(T::trans('Security token has expired, please submit the form again'));
         

--- a/src/forms/InsertSectionForm.php
+++ b/src/forms/InsertSectionForm.php
@@ -61,9 +61,6 @@ class InsertSectionForm extends MakeupForm
             ->setHtmlAttribute('data-parent', 'options')
             ->setAttribute('data-autoresize');
         
-        $form->addCheckbox('trgs', T::trans('Open in New Window?'))
-            ->setHtmlAttribute('data-parent', 'options')
-            ->setAttribute('data-autoresize');
 
         $form->addProtection(T::trans('Security token has expired, please submit the form again'));
         

--- a/src/forms/ModifySectionForm.php
+++ b/src/forms/ModifySectionForm.php
@@ -73,16 +73,10 @@ class ModifySectionForm extends MakeupForm
                 $form['option_content']->setDefaultValue($page[$rowIndex]['v1']);
             }
             
-            if ($page[$rowIndex]['key'] == 'imageURL' || $page[$rowIndex]['key'] == 'linkButton') { 
-                $name = $page[$rowIndex]['v2']; 
-            } else { 
-                $name = ''; 
-            }
-            
-            if ($page[$rowIndex]['key'] == 'linkButton') { 
-                ($page[$rowIndex]['v3']) ? $trg = true : $trg = false;
-            } else { 
-                $trg = false; 
+            if ($page[$rowIndex]['key'] == 'imageURL') {
+                $name = $page[$rowIndex]['v2'];
+            } else {
+                $name = '';
             }
                 
                 $form->addTextArea('names', T::trans('Name'))
@@ -90,10 +84,6 @@ class ModifySectionForm extends MakeupForm
                     ->setAttribute('data-autoresize')
                 	->setDefaultValue($name);
                 	
-                $form->addCheckbox('trgs', T::trans('Open in New Window?'))
-                    ->setHtmlAttribute('data-parent', 'options')
-                    ->setAttribute('data-autoresize')
-                	->setDefaultValue($trg);
         	
         } 
 

--- a/src/forms/UpdatePageForm.php
+++ b/src/forms/UpdatePageForm.php
@@ -73,16 +73,10 @@ class UpdatePageForm extends MakeupForm
                     $form['option_content'.$index]->setDefaultValue($fields['v1']);
                 }
                 
-                if ($fields['key'] == 'imageURL' || $fields['key'] == 'linkButton') { 
-                    $name = $fields['v2']; 
-                } else { 
-                    $name = $fields['v1']; 
-                }
-                
-                if ($fields['key'] == 'linkButton') { 
-                    ($fields['v3']) ? $trg = true : $trg = false; 
-                } else { 
-                    $trg = false; 
+                if ($fields['key'] == 'imageURL') {
+                    $name = $fields['v2'];
+                } else {
+                    $name = $fields['v1'];
                 }
             
                 $form->addTextArea('names'.$index, T::trans('Name'))
@@ -90,10 +84,6 @@ class UpdatePageForm extends MakeupForm
                     ->setAttribute('data-autoresize')
                 	->setDefaultValue($name);
                 	
-                $form->addCheckbox('trgs'.$index, T::trans('Open in New Window?'))
-                    ->setHtmlAttribute('data-parent', 'options'.$index)
-                    ->setAttribute('data-autoresize')
-                	->setDefaultValue($trg);
             
         $index++;
         	
@@ -113,7 +103,6 @@ class UpdatePageForm extends MakeupForm
                             'option_content'=> (isset($values['option_content'.$x])) ? $values['option_content'.$x] : '',
                             'language'      => (isset($values['language'.$x])) ? $values['language'.$x] : '',
                             'names'         => (isset($values['names'.$x])) ? $values['names'.$x] : '',
-                            'trgs'          => (isset($values['trgs'.$x])) ? $values['trgs'.$x] : '',
                             'file'          => ($values['file'.$x]->hasFile()) ? $values['file'.$x] : $page[$x]['v1']
                             );
             

--- a/src/lib/DocBuilder.php
+++ b/src/lib/DocBuilder.php
@@ -64,9 +64,6 @@ class DocBuilder
                 case 'imageURL':
 					$option = $this->imageURL($jsonVals['v1'], $jsonVals['v2']);
                     break;
-                case 'linkButton':
-					$option = $this->linkButton($jsonVals['v1'], $jsonVals['v2'], $jsonVals['v3']);
-                    break;
                 case 'markdown':
 					$option = $this->markdown($jsonVals['v1']);
                     break;
@@ -119,9 +116,6 @@ class DocBuilder
                     break;
                 case 'imageURL':
 					$option = ['key' => $values['options'], 'v1' => $values['option_content'], 'v2' => $values['names'], 'v3' => '', 'v4' => ''];
-                    break;
-                case 'linkButton':
-					$option = ['key' => $values['options'], 'v1' => $values['option_content'], 'v2' => $values['names'], 'v3' => $values['trgs'], 'v4' => ''];
                     break;
                 case 'markdown':
 					$option = ['key' => $values['options'], 'v1' => $values['option_content'], 'v2' => '', 'v3' => '', 'v4' => ''];
@@ -578,22 +572,6 @@ $identifier),\n";
         
     }
     
-    /**
-     * linkButton
-     *
-     * @param  string $src
-     * @param  string $val
-     * @param  string $trg
-     *
-     * @return string
-     */
-    public function linkButton($src,$val,$trg)
-    {
-        $val = TextHelper::e($val);
-        $src = TextHelper::e($src);
-        $out = '$html->linkButton'."('{$src}','{$val}','{$trg}'), \n";
-        return $out;
-    }
     
     /**
      * getOptions
@@ -611,9 +589,8 @@ $identifier),\n";
     	'image' => T::trans('Add image from file'),
     	'pathAdd'  => T::trans('Add path'),
     	'codeInline' => T::trans('Add code inline'),
-    	'codeFile' => T::trans('Add code from file'),
-    	'linkButton' => T::trans('Add link button')
-    	];
+        'codeFile' => T::trans('Add code from file')
+        ];
     }
 
 

--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -231,20 +231,6 @@ class DocPHT {
     }
 
 
-    /**
-     * linkButton
-     *
-     * @param  string $url
-     * @param  string $title
-     * @param  boolean $target
-     *
-     * @return string
-     */
-    public function linkButton(string $url, string $title, $target = false)
-    {
-        $setTarget = ($target) ? 'target="_blank"' : '' ;
-        return '<tr>'. ((isset($_SESSION['Active'])) ? '<td class="handle"><i class="fa fa-arrows-v sort"></i></td>' : '') . '<td><span class="spinner-grow spinner-grow-sm text-secondary"></span><a href="'.$url.'" '.$setTarget.' class="link" role="button">'.$title.'</a>'.$this->insertBeforeButton().$this->removeButton().$this->modifyButton().$this->insertAfterButton().'</td></tr>';
-    }
 
     /**
      * markdown

--- a/src/translations/zh_CN.php
+++ b/src/translations/zh_CN.php
@@ -27,7 +27,6 @@
         'Add image' => '添加图片',
         'Add markdown' => '添加 Markdown',
         'Add markdown from file' => '从文件添加 Markdown',
-        'Add link button' => '添加链接按钮',
         'Options:' => '选项：',
         'Select an option' => '选择一个选项',
         'Language:' => '语言：',


### PR DESCRIPTION
## Summary
- remove link button translations and builder option
- drop link button method from DocPHT
- clean up forms and javascript related to removed block
- remove checkbox field for target in all forms

## Testing
- `php tests/check_discuz_login.php`
- `php -l src/lib/DocBuilder.php`
- `php -l src/lib/DocPHT.php`
- `php -l src/forms/AddSectionForm.php`
- `php -l src/forms/InsertSectionForm.php`
- `php -l src/forms/ModifySectionForm.php`
- `php -l src/forms/UpdatePageForm.php`
- `php -l src/translations/zh_CN.php`


------
https://chatgpt.com/codex/tasks/task_e_68672e2534f08328bc03342e6bb009e6