### PR TITLE
Remove obsolete description block type

### DIFF
--- a/public/assets/js/doc-pht.js
+++ b/public/assets/js/doc-pht.js
@@ -210,9 +210,6 @@ function updateOptionFields() {
                 case "title":
                     all_option_content[i].label.innerHTML = 'Title:';
                     break;
-                case "description":
-                    all_option_content[i].label.innerHTML = 'Description:';
-                    break;
                 case "pathAdd":
                     all_option_content[i].label.innerHTML = 'Path:';
                     break;

--- a/src/forms/CreatePageForm.php
+++ b/src/forms/CreatePageForm.php
@@ -64,9 +64,6 @@ class CreatePageForm extends MakeupForm
             ->setRequired(T::trans('Title is required.'))
             ->setDefaultValue(isset($_GET['title']) ? htmlspecialchars($_GET['title'], ENT_QUOTES, 'UTF-8') : '');
 
-        $form->addTextArea('description', T::trans('Description'))
-            ->setHtmlAttribute('placeholder', T::trans('Enter a description'))
-            ->setRequired(T::trans('Description is required.'));
 
         $form->addUpload('file', T::trans('Add an image or a code file'))
             ->setRequired(false)
@@ -92,10 +89,6 @@ class CreatePageForm extends MakeupForm
             $ok = $ok && $this->pageModel->addPageData(
                 $id,
                 $this->doc->valuesToArray(['options' => 'title', 'option_content' => $values['title']])
-            );
-            $ok = $ok && $this->pageModel->addPageData(
-                $id,
-                $this->doc->valuesToArray(['options' => 'description', 'option_content' => $values['description']])
             );
 
             $file = $values['file'];

--- a/src/translations/zh_CN.php
+++ b/src/translations/zh_CN.php
@@ -18,7 +18,6 @@
         'Page name' => '页面名称',
         'Enter page name' => '输入页面名称',
         'Add title' => '添加标题',
-        'Add description' => '添加描述',
         'Add path' => '添加路径',
         'Aggiungi percorso' => '添加路径',
         'Add code inline' => '添加内联代码',


### PR DESCRIPTION
## Summary
- drop `Add description` from Chinese translations
- remove description textarea and page data from page creation form
- clean description option from frontend logic

## Testing
- `php -l src/forms/CreatePageForm.php`
- `php -l src/translations/zh_CN.php`


------
https://chatgpt.com/codex/tasks/task_e_686737c5bb9483288ce493fd3f21b26c