### PR TITLE
Enable editing for flat files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Guidelines
+
+- Run `php -l <file>` on any modified PHP files before committing.
+- Run `jshint <file>` on any modified JavaScript files before committing.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ For small sites this repository also includes a very basic "flat" mode where
 each page lives as a single Markdown file under the `flat/` directory. The new
 `FlatPageModel` (see `src/model/FlatPageModel.php`) can read and write these
 files and `flat_doc.php` renders them using the same `MediaWikiParsedown`
-parser employed by the rest of the documentation.
+parser employed by the rest of the documentation. Logged in users can edit a
+flat page through `flat_edit.php?page=<slug>` which saves the Markdown back to
+`flat/`.
 
 This mode drops all advanced DocPHT features such as attachments, code blocks
 and versioning so only raw Markdown is supported.

--- a/flat_doc.php
+++ b/flat_doc.php
@@ -80,5 +80,5 @@ foreach ($segments as $segment) {
 }
 $values[] = $html->addButton();
 
-$view->show('page/page.php', ['values' => $values]);
+$view->show('page/page.php', ['values' => $values, 'flatSlug' => $slug]);
 $view->show('partial/footer.php');

--- a/flat_edit.php
+++ b/flat_edit.php
@@ -1,0 +1,59 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/src/config/config.php';
+
+use DocPHT\Core\Session\Session;
+use DocPHT\Core\Helper\DiscuzBridge;
+use DocPHT\Model\FlatPageModel;
+use Instant\Core\Views\View;
+
+$session = new Session();
+$session->sessionExpiration();
+$session->preventStealingSession();
+DiscuzBridge::syncSession();
+
+if (!isset($_SESSION['Active'])) {
+    http_response_code(403);
+    echo 'Unauthorized';
+    exit;
+}
+
+$slug = $_GET['page'] ?? '';
+if ($slug === '') {
+    http_response_code(400);
+    echo 'Missing page parameter';
+    exit;
+}
+
+$model = new FlatPageModel();
+$markdown = $model->get($slug);
+if ($markdown === null) {
+    $markdown = '';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $content = $_POST['markdown'] ?? '';
+    if ($model->put($slug, $content)) {
+        header('Location: flat_doc.php?page=' . rawurlencode($slug));
+        exit;
+    }
+    echo 'Failed to save';
+}
+
+$view = new View();
+$view->show('partial/head.php', ['PageTitle' => 'Edit ' . htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')]);
+include 'src/views/partial/sidebar_button.php';
+?>
+<div class="card fade-in-fwd">
+    <div class="card-body">
+        <form method="post">
+            <div class="form-group">
+                <textarea name="markdown" class="form-control" rows="20" data-autoresize required><?php echo htmlspecialchars($markdown); ?></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Save</button>
+            <a href="flat_doc.php?page=<?php echo htmlspecialchars($slug); ?>" class="btn btn-secondary">Cancel</a>
+        </form>
+    </div>
+</div>
+<?php
+$view->show('partial/footer.php');

--- a/flat_edit.php
+++ b/flat_edit.php
@@ -31,13 +31,15 @@ if ($markdown === null) {
     $markdown = '';
 }
 
+$saveError = null;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $content = $_POST['markdown'] ?? '';
-    if ($model->put($slug, $content)) {
+    // Use submitted content for saving and for redisplaying on failure
+    $markdown = $_POST['markdown'] ?? '';
+    if ($model->put($slug, $markdown)) {
         header('Location: flat_doc.php?page=' . rawurlencode($slug));
         exit;
     }
-    echo 'Failed to save';
+    $saveError = 'Failed to save the page. Please try again.';
 }
 
 $view = new View();
@@ -46,6 +48,11 @@ include 'src/views/partial/sidebar_button.php';
 ?>
 <div class="card fade-in-fwd">
     <div class="card-body">
+        <?php if ($saveError): ?>
+            <div class="alert alert-danger" role="alert">
+                <?= htmlspecialchars($saveError, ENT_QUOTES, 'UTF-8') ?>
+            </div>
+        <?php endif; ?>
         <form method="post">
             <div class="form-group">
                 <textarea name="markdown" class="form-control" rows="20" data-autoresize required><?php echo htmlspecialchars($markdown); ?></textarea>

--- a/src/views/page/page.php
+++ b/src/views/page/page.php
@@ -20,6 +20,13 @@ if (isset($_SESSION['Active']) && $versions['state'] == 0) {
                 </button>
             </li>
         </ul>';
+} else if (isset($flatSlug) && isset($_SESSION['Active'])) {
+    echo '<ul class="list-inline text-right mt-4">'
+        .'<li class="list-inline-item" data-toggle="tooltip" data-placement="bottom" title="Edit markdown">'
+        .'<a href="flat_edit.php?page='.htmlspecialchars($flatSlug, ENT_QUOTES, 'UTF-8').'" class="btn btn-outline-info btn-sm" role="button">'
+        .'<i class="fa fa-pencil-square" aria-hidden="true"></i></a>'
+        .'</li>'
+        .'</ul>';
 } else if (isset($_SESSION['Active']) && $versions['state'] > 0){
     echo '<ul class="list-inline text-right mt-4">'
             .'<li class="list-inline-item" data-toggle="tooltip" data-placement="bottom" title="'.$t->trans("Update").'">


### PR DESCRIPTION
## Summary
- enable editing for Markdown files in flat mode
- add link to open new flat_edit.php page
- document new edit workflow

## Testing
- `php -l flat_edit.php`
- `php -l src/views/page/page.php`
- `php -l flat_doc.php`

------
https://chatgpt.com/codex/tasks/task_e_68673d5ffec8832891df88ac00083b66