### PR TITLE
Disable underscore emphasis in Parsedown

### DIFF
--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -24,7 +24,6 @@ class MediaWikiParsedown extends ParsedownPlus
 
         // disable underscore for emphasis to allow LaTeX formulas
         unset($this->InlineTypes['_']);
-        $this->inlineMarkerList = str_replace('_', '', $this->inlineMarkerList);
         if (($k = array_search('_', $this->specialCharacters, true)) !== false) {
             unset($this->specialCharacters[$k]);
         }

--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -21,8 +21,16 @@ class MediaWikiParsedown extends ParsedownPlus
     {
         parent::__construct();
         $this->InlineTypes['['][] = 'MediaWikiUrl';
+
+        // disable underscore for emphasis to allow LaTeX formulas
+        unset($this->InlineTypes['_']);
+        $this->inlineMarkerList = str_replace('_', '', $this->inlineMarkerList);
+        if (($k = array_search('_', $this->specialCharacters, true)) !== false) {
+            unset($this->specialCharacters[$k]);
+        }
+        unset($this->StrongRegex['_'], $this->EmRegex['_']);
     }
-    protected $inlineMarkerList = '!*_&[:<`~\\';
+    protected $inlineMarkerList = '!*&[:<`~\\';
 
     protected function inlineMediaWikiUrl($Excerpt)
     {


### PR DESCRIPTION
## Summary
- update `MediaWikiParsedown` constructor to remove underscore delimiter
- adjust `inlineMarkerList` accordingly

## Testing
- `php -l src/lib/DocPHT.php`


------
https://chatgpt.com/codex/tasks/task_e_6867535229b08328a85ea73cc194f6df