### PR TITLE
Add lazy loading to LaTeX images

### DIFF
--- a/public/assets/js/latex.js
+++ b/public/assets/js/latex.js
@@ -250,6 +250,7 @@
     i.setAttribute('class', 'latex-' + ext);
     i.setAttribute('style', 'vertical-align:middle; border:0;');
     i.setAttribute('alt', cleanedFormula);
+    i.setAttribute('loading', 'lazy');
 
     isCentered && (i.style.margin = '0 0 0 auto');
 


### PR DESCRIPTION
## Summary
- set `loading="lazy"` attribute on LaTeX images in `public/assets/js/latex.js`

## Testing
- `jshint public/assets/js/latex.js`

------
https://chatgpt.com/codex/tasks/task_e_6867709a98e88328833e82337ad41ad7