### PR TITLE
Fix double escaping in markdown parser

### DIFF
--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -110,6 +110,20 @@ class MediaWikiParsedown extends ParsedownPlus
 
         return $Block;
     }
+
+    // Preserve escape sequences for backslash and dollar sign so that
+    // MathJax can handle them on the frontend without double escaping
+    protected function inlineEscapeSequence($Excerpt)
+    {
+        if (isset($Excerpt['text'][1]) && in_array($Excerpt['text'][1], ['\\', '$'])) {
+            return [
+                'markup' => $Excerpt['text'],
+                'extent' => 2,
+            ];
+        }
+
+        return parent::inlineEscapeSequence($Excerpt);
+    }
 }
 
 class DocPHT {


### PR DESCRIPTION
## Summary
- preserve `\` and `$` escape sequences in `MediaWikiParsedown`

## Testing
- `php -l src/lib/DocPHT.php`

------
https://chatgpt.com/codex/tasks/task_e_686794f9410c8328999b5f5bb0aa9e2a