### PR TITLE
Remove DocPHT blockquote block type

### DIFF
--- a/public/assets/js/doc-pht.js
+++ b/public/assets/js/doc-pht.js
@@ -216,9 +216,6 @@ function updateOptionFields() {
                 case "title":
                     all_option_content[i].label.innerHTML = 'Title:';
                     break;
-                case "blockquote":
-                    all_option_content[i].label.innerHTML = 'Block Quote:';
-                    break;
                 default:
                     all_option_content[i].label.innerHTML = 'Content:';
             }

--- a/src/lib/DocBuilder.php
+++ b/src/lib/DocBuilder.php
@@ -49,9 +49,6 @@ class DocBuilder
                 case 'codeFile':
 					$option = $this->codeFile($jsonVals['v1'], $jsonVals['v2']);
                     break;
-                case 'blockquote':
-                    $option = $this->blockquote($jsonVals['v1']);
-                    break;
                 case 'image':
 					$option = $this->image($jsonVals['v1'], $jsonVals['v2']);
                     break;
@@ -98,9 +95,6 @@ class DocBuilder
                     break;
                 case 'codeFile':
                     $option = ['key' => $values['options'], 'v1' => substr($file_path, 5), 'v2' => $values['language'], 'v3' => '', 'v4' => ''];
-                    break;
-                case 'blockquote':
-                    $option = ['key' => $values['options'], 'v1' => $values['option_content'], 'v2' => '', 'v3' => '', 'v4' => ''];
                     break;
                 case 'image':
                     $option = ['key' => $values['options'], 'v1' => substr($file_path, 5), 'v2' => $values['option_content'], 'v3' => '', 'v4' => ''];
@@ -411,19 +405,6 @@ class DocBuilder
         
     }
     
-    /**
-     * blockquote
-     *
-     * @param  string $val
-     *
-     * @return string
-     */
-    public function blockquote($val)
-    {
-        $val = TextHelper::e($val);
-        $out = '$html->blockquote'."('{$val}'), \n";
-        return $out; 
-    }
     
     /**
      * image
@@ -528,8 +509,7 @@ $identifier),\n";
         'title' => T::trans('Add title'),
     	'markdown' => T::trans('Add markdown'),
     	'markdownFile' => T::trans('Add markdown from file'),
-    	'imageURL' => T::trans('Add image from url'),
-    	'blockquote' => T::trans('Add blockquote'),
+        'imageURL' => T::trans('Add image from url'),
         'image' => T::trans('Add image from file'),
         'codeInline' => T::trans('Add code inline'),
         'codeFile' => T::trans('Add code from file')

--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -206,18 +206,6 @@ class DocPHT {
         }
     }
 
-    /**
-     * blockquote
-     *
-     * @param  string $blockquote
-     *
-     * @return string
-     */
-    public function blockquote(string $blockquote)
-    {
-       $blockquote = nl2br($blockquote);
-       return '<tr>'. ((isset($_SESSION['Active'])) ? '<td class="handle"><i class="fa fa-arrows-v sort"></i></td>' : '') . '<td><blockquote>'.$blockquote.' '.$this->insertBeforeButton().$this->removeButton().$this->modifyButton().$this->insertAfterButton().'</blockquote></td></tr>';
-    }
 
     /**
      * codeInline

--- a/src/translations/zh_CN.php
+++ b/src/translations/zh_CN.php
@@ -20,7 +20,6 @@
         'Add title' => '添加标题',
         'Add code inline' => '添加内联代码',
         'Add code from file' => '从文件添加代码',
-        'Add blockquote' => '添加引用块',
         'Add image' => '添加图片',
         'Add markdown' => '添加 Markdown',
         'Add markdown from file' => '从文件添加 Markdown',


### PR DESCRIPTION
## Summary
- remove `blockquote` option from DocBuilder
- drop blockquote rendering helper from DocPHT
- update JavaScript to drop blockquote handling
- clean up Chinese translation

## Testing
- `jshint public/assets/js/doc-pht.js` *(fails: command not found)*
- `php -l src/lib/DocBuilder.php` *(fails: command not found)*
- `php -l src/lib/DocPHT.php` *(fails: command not found)*
- `php -l src/translations/zh_CN.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681e7283108328b3e33ac5283cb70f