### PR TITLE
Switch to using slug as page identifier

### DIFF
--- a/src/forms/BackupsForms.php
+++ b/src/forms/BackupsForms.php
@@ -160,9 +160,9 @@ class BackupsForms extends MakeupForm
         $zipData = new \ZipArchive();
         if (!empty($zip_file)) {
             if ($zipData->open($zip_file) === TRUE) {
-                $oldIds = $this->pageModel->getAllFromKey('id');
+                $oldIds = $this->pageModel->getAllFromKey('slug');
                 $new = json_decode(file_get_contents("zip://".$zip_file."#json/pages.json"),true);
-                $newIds = $this->pageModel->getAllFromDataKey($new, 'id');
+                $newIds = $this->pageModel->getAllFromDataKey($new, 'slug');
                 
                 foreach($newIds as $id) {
                     $this->pageModel->remove($id);

--- a/src/forms/PublishPageForm.php
+++ b/src/forms/PublishPageForm.php
@@ -23,7 +23,7 @@ class PublishPageForm extends MakeupForm
 
         foreach ($pages as $key => $value) {
 
-            if ($value['pages']['id'] === $id) {
+            if ($value['pages']['slug'] === $id) {
                 if ($value['pages']['published'] === 0 && $value['pages']['home'] !== 1) {
                     $published = 1;
                 } else {
@@ -31,7 +31,6 @@ class PublishPageForm extends MakeupForm
                 }
                 $pages[$key] = array(
                     'pages' => [
-                        'id' => $value['pages']['id'],
                         'slug' => $value['pages']['slug'],
                         'topic' => $value['pages']['topic'],
                         'filename' => $value['pages']['filename'],

--- a/src/forms/SearchForm.php
+++ b/src/forms/SearchForm.php
@@ -29,7 +29,7 @@ class SearchForm extends MakeupForm
             $pages = $this->pageModel->connect();
 
                     foreach($json as $value)  {
-                        $id = $value['id'];
+                        $id = $value['slug'];
                         $value = $value['content'];
                         if(!empty($searchthis) && preg_match("#($searchthis)#", strtolower($value)))  {
 
@@ -39,7 +39,7 @@ class SearchForm extends MakeupForm
                             $value = substr($value, 0, 100) . '...';
 
                             foreach ($pages as $val) {
-                                if ($val['pages']['id'] == $id) {
+                                if ($val['pages']['slug'] == $id) {
                                     $found[] =  array(
                                             'content' => '<div class="result-preview">'
                                                     . '<a href="/page/'.$this->pageModel->getSlug($id).'">'

--- a/src/model/BackupsModel.php
+++ b/src/model/BackupsModel.php
@@ -142,8 +142,8 @@ class BackupsModel extends PageModel
         
         if (is_array($pages) && count($pages) > 0) {
             foreach($pages as $page) {
-                ($this->versionModel->getAssets($page['pages']['id']) !== false) ? $asset = $this->versionModel->getAssets($page['pages']['id']) : $asset = '';
-                ($this->versionModel->getVersions($page['pages']['id']) !== false) ? $version = $this->versionModel->getVersions($page['pages']['id']) : $version = [];
+                ($this->versionModel->getAssets($page['pages']['slug']) !== false) ? $asset = $this->versionModel->getAssets($page['pages']['slug']) : $asset = '';
+                ($this->versionModel->getVersions($page['pages']['slug']) !== false) ? $version = $this->versionModel->getVersions($page['pages']['slug']) : $version = [];
                 
                 foreach($asset as $a) { array_push($assets, $a); }
                 if(!empty($version))foreach($version as $ver) { array_push($assets, $ver['path']); }

--- a/src/model/PageModel.php
+++ b/src/model/PageModel.php
@@ -75,7 +75,7 @@ class PageModel
         $data = $this->connect();
         foreach ($data as $value) {
             if ($value['pages']['slug'] === $slug) {
-                return $value['pages']['id'];
+                return $value['pages']['slug'];
             }
         }
         return null;
@@ -136,10 +136,10 @@ class PageModel
     public function create($topic, $filename)
     {
         $data = $this->connect();
-        $id = uniqid();
         $topic = pathinfo($topic, PATHINFO_FILENAME);
         $filename = pathinfo($filename, PATHINFO_FILENAME);
         $slug = trim($topic) . '/' . trim($filename);
+        $id = $slug;
         $fileSlug = $this->computeFileSlug($topic, $filename);
 
         if (!is_null($data)) {
@@ -160,7 +160,6 @@ class PageModel
         
         $data[] = array(
             'pages' => [
-                    'id' => $id,
                     'slug' => $slug,
                     'topic' => $topic,
                     'filename' => $filename,
@@ -353,7 +352,7 @@ class PageModel
             $fileSlug = isset($value['pages']['file_slug']) ? $value['pages']['file_slug'] : $this->computeFileSlug($value['pages']['topic'], $value['pages']['filename']);
             $phpPath = 'pages/'.$fileSlug.'.php';
             if ($phpPath === $path) {
-                return $value['pages']['id'];
+                return $value['pages']['slug'];
             }
         }
 
@@ -551,7 +550,7 @@ class PageModel
         $x = 0;
         if (isset($data)) {
             foreach ($data as $array) {
-                if ($array['pages']['id'] == $search) $key = $x;
+                if ($array['pages']['slug'] == $search) $key = $x;
                 $x++;
             }
             

--- a/src/model/SearchModel.php
+++ b/src/model/SearchModel.php
@@ -25,15 +25,15 @@ class SearchModel extends PageModel
         $array = [];
         if($data !== false){
             foreach ($data as $value) {
-                if(!empty($value['id'])) {
-                    (!empty($value['topic'])) ? array_push($array, $this->add($value['id'], $value['topic'])) : $array;
-                    (!empty($value['topic'])) ? array_push($array, $this->add($value['id'], $value['filename'])) : $array;
+                if(!empty($value['slug'])) {
+                    (!empty($value['topic'])) ? array_push($array, $this->add($value['slug'], $value['topic'])) : $array;
+                    (!empty($value['topic'])) ? array_push($array, $this->add($value['slug'], $value['filename'])) : $array;
                 }
-                foreach($this->getPageData($value['id']) as $page) {
-                    (!empty($page['v1'])) ? array_push($array,$this->add($value['id'], $page['v1'])) : $array;
-                    (!empty($page['v2'])) ? array_push($array,$this->add($value['id'], $page['v2'])) : $array;
-                    (!empty($page['v3'])) ? array_push($array,$this->add($value['id'], $page['v3'])) : $array;
-                    (!empty($page['v4'])) ? array_push($array,$this->add($value['id'], $page['v4'])) : $array;
+                foreach($this->getPageData($value['slug']) as $page) {
+                    (!empty($page['v1'])) ? array_push($array,$this->add($value['slug'], $page['v1'])) : $array;
+                    (!empty($page['v2'])) ? array_push($array,$this->add($value['slug'], $page['v2'])) : $array;
+                    (!empty($page['v3'])) ? array_push($array,$this->add($value['slug'], $page['v3'])) : $array;
+                    (!empty($page['v4'])) ? array_push($array,$this->add($value['slug'], $page['v4'])) : $array;
                 }
             }
         }
@@ -43,7 +43,7 @@ class SearchModel extends PageModel
     public function add($id, $content)
     {
         return [
-                    'id' => $id,
+                    'slug' => $id,
                     'content' => $content
                 ];
     }

--- a/src/views/page/page.php
+++ b/src/views/page/page.php
@@ -47,7 +47,7 @@ if (!is_null($topics)) {
                     $x = 0;
                     $i = 0;
                     foreach($allpages as $page) {
-                        if ($page['id'] == $_SESSION['page_id']) {
+                        if ($page['slug'] == $_SESSION['page_id']) {
                             $i = $x;
                         }
                         $x++;


### PR DESCRIPTION
## Summary
- remove uniqid page IDs and rely on slug for page identity
- adjust page lookup logic to use slug
- update publishing and search code for slug usage
- update backup and search model helpers
- update navigation to track slug

## Testing
- `php -l src/forms/BackupsForms.php`
- `php -l src/forms/PublishPageForm.php`
- `php -l src/forms/SearchForm.php`
- `php -l src/model/BackupsModel.php`
- `php -l src/model/PageModel.php`
- `php -l src/model/SearchModel.php`
- `php -l src/views/page/page.php`

------
https://chatgpt.com/codex/tasks/task_e_686925b6f1088328a0bd548f3f0b49a1