### PR TITLE
Refactor slug handling and clean search code

### DIFF
--- a/src/controller/FormPageController.php
+++ b/src/controller/FormPageController.php
@@ -27,15 +27,14 @@ class FormPageController extends BaseController
         public function getPage($topic, $filename)
         {
                 $slug = $topic.'/'.$filename;
-                $id = $this->pageModel->getIdBySlug($slug);
-                if ($id === null) {
+                if (!$this->pageModel->slugExists($slug)) {
                         $error = new ErrorPageController();
                         $error->getPage($topic, $filename);
                         return;
                 }
 
                 $this->view->show('partial/head.php', ['PageTitle' => $topic .' '. $filename]);
-                $path = $this->pageModel->getPhpPath($id);
+                $path = $this->pageModel->getPhpPath($slug);
                 $values = require $path;
                 $this->view->show('page/page.php', ['values' => $values]);
                 $this->view->show('partial/footer.php');

--- a/src/forms/AddSectionForm.php
+++ b/src/forms/AddSectionForm.php
@@ -21,7 +21,7 @@ class AddSectionForm extends MakeupForm
 
     public function create()
     {
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         $options = $this->doc->getOptions();
 
         $form = new Form;

--- a/src/forms/BackupsForms.php
+++ b/src/forms/BackupsForms.php
@@ -160,12 +160,12 @@ class BackupsForms extends MakeupForm
         $zipData = new \ZipArchive();
         if (!empty($zip_file)) {
             if ($zipData->open($zip_file) === TRUE) {
-                $oldIds = $this->pageModel->getAllFromKey('slug');
+                $oldSlugs = $this->pageModel->getAllFromKey('slug');
                 $new = json_decode(file_get_contents("zip://".$zip_file."#json/pages.json"),true);
-                $newIds = $this->pageModel->getAllFromDataKey($new, 'slug');
-                
-                foreach($newIds as $id) {
-                    $this->pageModel->remove($id);
+                $newSlugs = $this->pageModel->getAllFromDataKey($new, 'slug');
+
+                foreach($newSlugs as $slug) {
+                    $this->pageModel->remove($slug);
                 }
                 
                 $join = array_merge($this->pageModel->connect(), $new); 

--- a/src/forms/DeletePageForm.php
+++ b/src/forms/DeletePageForm.php
@@ -19,7 +19,7 @@ class DeletePageForm extends MakeupForm
 
     public function delete()
     {
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         $uPath = $this->pageModel->getPhpPath($id);
         $data = $this->pageModel->getPageData($id);
     
@@ -31,7 +31,7 @@ class DeletePageForm extends MakeupForm
         (file_exists($this->pageModel->getPhpPath($id))) ? unlink($this->pageModel->getPhpPath($id)) : NULL;
         (file_exists($this->pageModel->getJsonPath($id))) ? unlink($this->pageModel->getJsonPath($id)) : NULL;
     
-        if (isset($_SESSION['Active']) && isset($_SESSION['page_id'])) {
+        if (isset($_SESSION['Active']) && isset($_SESSION['page_slug'])) {
             if ($uPath == 'json/doc-pht/home.php') {
                 $zippedVersionPath = 'json/doc-pht/';
                 $filePattern = 'home_*.zip';

--- a/src/forms/InsertSectionForm.php
+++ b/src/forms/InsertSectionForm.php
@@ -21,7 +21,7 @@ class InsertSectionForm extends MakeupForm
 
     public function create()
     {
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         $uPath = $this->pageModel->getPhpPath($id);
         $options = $this->doc->getOptions();
 

--- a/src/forms/ModifySectionForm.php
+++ b/src/forms/ModifySectionForm.php
@@ -21,7 +21,7 @@ class ModifySectionForm extends MakeupForm
 
     public function create()
     {
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         $options = $this->doc->getOptions();
 
         $form = new Form;

--- a/src/forms/PublishPageForm.php
+++ b/src/forms/PublishPageForm.php
@@ -18,7 +18,7 @@ class PublishPageForm extends MakeupForm
 {
     public function publish()
     {
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         $pages = $this->pageModel->connect();
 
         foreach ($pages as $key => $value) {

--- a/src/forms/RemoveSectionForm.php
+++ b/src/forms/RemoveSectionForm.php
@@ -22,7 +22,7 @@ class RemoveSectionForm extends MakeupForm
     public function create()
     {
 
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         
         if(isset($_GET['id'])) {
             $rowIndex = intval($_GET['id']);

--- a/src/forms/SearchForm.php
+++ b/src/forms/SearchForm.php
@@ -29,7 +29,7 @@ class SearchForm extends MakeupForm
             $pages = $this->pageModel->connect();
 
                     foreach($json as $value)  {
-                        $id = $value['slug'];
+                        $slug = $value['slug'];
                         $value = $value['content'];
                         if(!empty($searchthis) && preg_match("#($searchthis)#", strtolower($value)))  {
 
@@ -39,12 +39,12 @@ class SearchForm extends MakeupForm
                             $value = substr($value, 0, 100) . '...';
 
                             foreach ($pages as $val) {
-                                if ($val['pages']['slug'] == $id) {
+                                if ($val['pages']['slug'] == $slug) {
                                     $found[] =  array(
                                             'content' => '<div class="result-preview">'
-                                                    . '<a href="/page/'.$this->pageModel->getSlug($id).'">'
+                                                    . '<a href="/page/'.$slug.'">'
                                                         . '<h3 class="result-title">'
-                                                            .$this->pageModel->getTopic($id).' '.$this->pageModel->getFilename($id).'
+                                                            .$this->pageModel->getTopic($slug).' '.$this->pageModel->getFilename($slug).'
                                                         </h3>'
                                                         . '<p class="result-subtitle">'
                                                             .$value

--- a/src/forms/UpdatePageForm.php
+++ b/src/forms/UpdatePageForm.php
@@ -22,7 +22,7 @@ class UpdatePageForm extends MakeupForm
     public function create()
     {
 
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         $options = $this->doc->getOptions();
 
         $form = new Form;

--- a/src/forms/VersionForms.php
+++ b/src/forms/VersionForms.php
@@ -21,7 +21,7 @@ class VersionForms extends MakeupForm
 
     public function import()
     {
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         $aPath = $this->versionModel->getPhpPath($id);
 
         $form = new Form;
@@ -65,16 +65,16 @@ class VersionForms extends MakeupForm
     
     public function delete()
     {    
-        if (isset($_POST['version']) && isset($_SESSION['page_id'])) {
+        if (isset($_POST['version']) && isset($_SESSION['page_slug'])) {
             ($this->versionModel->deleteVersion($_POST['version'])) 
-            ? header('Location:'.$this->pageModel->getTopic($_SESSION['page_id']).'/'.$this->pageModel->getFilename($_SESSION['page_id'])) 
-            : $this->msg->error(T::trans('Sorry something didn\'t work!'),BASE_URL.'page/'.$this->pageModel->getTopic($_SESSION['page_id']).'/'.$this->pageModel->getFilename($_SESSION['page_id']));
+            ? header('Location:'.$this->pageModel->getTopic($_SESSION['page_slug']).'/'.$this->pageModel->getFilename($_SESSION['page_slug'])) 
+            : $this->msg->error(T::trans('Sorry something didn\'t work!'),BASE_URL.'page/'.$this->pageModel->getTopic($_SESSION['page_slug']).'/'.$this->pageModel->getFilename($_SESSION['page_slug']));
         }
     }
     
     public function export()
     {    
-        if (isset($_POST['version']) && isset($_SESSION['page_id'])) {
+        if (isset($_POST['version']) && isset($_SESSION['page_slug'])) {
             $filename = $_POST['version'];
             if (file_exists($filename)) {
                 header('Content-Description: File Transfer');
@@ -87,16 +87,16 @@ class VersionForms extends MakeupForm
                 readfile($filename);
                 exit;
             }
-            $this->msg->error(T::trans('Invalid procedure! File not found.'),BASE_URL.'page/'.$this->pageModel->getTopic($_SESSION['page_id']).'/'.$this->pageModel->getFilename($_SESSION['page_id']));
+            $this->msg->error(T::trans('Invalid procedure! File not found.'),BASE_URL.'page/'.$this->pageModel->getTopic($_SESSION['page_slug']).'/'.$this->pageModel->getFilename($_SESSION['page_slug']));
         } else {
-            $this->msg->error(T::trans('Invalid procedure! File not set.'),BASE_URL.'page/'.$this->pageModel->getTopic($_SESSION['page_id']).'/'.$this->pageModel->getFilename($_SESSION['page_id']));
+            $this->msg->error(T::trans('Invalid procedure! File not set.'),BASE_URL.'page/'.$this->pageModel->getTopic($_SESSION['page_slug']).'/'.$this->pageModel->getFilename($_SESSION['page_slug']));
         }
     }
     
     public function restore()
     {
-        if (isset($_POST['version']) && isset($_SESSION['page_id'])) {
-            $id = $_SESSION['page_id'];
+        if (isset($_POST['version']) && isset($_SESSION['page_slug'])) {
+            $id = $_SESSION['page_slug'];
             $versionZip = $_POST['version'];
             $aPath = $this->pageModel->getPhpPath($id);
             $jsonPath = $this->pageModel->getJsonPath($id);
@@ -127,7 +127,7 @@ class VersionForms extends MakeupForm
     
     public function save()
     {
-        $id = $_SESSION['page_id'];
+        $id = $_SESSION['page_slug'];
         if ($this->versionModel->saveVersion($id)) {
         	$this->msg->success(T::trans('Version saved successfully.'),BASE_URL.'page/'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
         } else {

--- a/src/forms/VersionSelectForm.php
+++ b/src/forms/VersionSelectForm.php
@@ -19,8 +19,8 @@ class VersionSelectForm extends MakeupForm
 {
     public function create()
     {
-        if (isset($_SESSION['Active']) && isset($_SESSION['page_id'])) {
-            $id = $_SESSION['page_id'];
+        if (isset($_SESSION['Active']) && isset($_SESSION['page_slug'])) {
+            $id = $_SESSION['page_slug'];
             
             $versionList = $this->versionModel->getVersions($id);
             

--- a/src/model/BackupsModel.php
+++ b/src/model/BackupsModel.php
@@ -142,8 +142,8 @@ class BackupsModel extends PageModel
         
         if (is_array($pages) && count($pages) > 0) {
             foreach($pages as $page) {
-                ($this->versionModel->getAssets($page['pages']['slug']) !== false) ? $asset = $this->versionModel->getAssets($page['pages']['slug']) : $asset = '';
-                ($this->versionModel->getVersions($page['pages']['slug']) !== false) ? $version = $this->versionModel->getVersions($page['pages']['slug']) : $version = [];
+                $asset = $this->versionModel->getAssets($page['pages']['slug']) ?: [];
+                $version = $this->versionModel->getVersions($page['pages']['slug']) ?: [];
                 
                 foreach($asset as $a) { array_push($assets, $a); }
                 if(!empty($version))foreach($version as $ver) { array_push($assets, $ver['path']); }

--- a/src/model/PageModel.php
+++ b/src/model/PageModel.php
@@ -21,7 +21,7 @@
  * getAllFromKey($key)
  * getAllFromDataKey($data, $key)
  * getAllIndexed()
- * getId($path)
+ * getSlugByPath($path)
  * getTopic($id)
  * getFilename($id)
  * getPageData($id)
@@ -70,15 +70,15 @@ class PageModel
         return $this->computeFileSlug($topic, $filename);
     }
 
-    public function getIdBySlug($slug)
+    public function slugExists($slug)
     {
         $data = $this->connect();
         foreach ($data as $value) {
             if ($value['pages']['slug'] === $slug) {
-                return $value['pages']['slug'];
+                return true;
             }
         }
-        return null;
+        return false;
     }
     
     
@@ -339,13 +339,13 @@ class PageModel
     }
     
     /**
-     * getId
+     * getSlugByPath
      *
      * @param  string $path
      *
      * @return string
      */
-    public function getId($path)
+    public function getSlugByPath($path)
     {
         $data = $this->connect();
         foreach ($data as $value) {

--- a/src/model/SearchModel.php
+++ b/src/model/SearchModel.php
@@ -25,25 +25,26 @@ class SearchModel extends PageModel
         $array = [];
         if($data !== false){
             foreach ($data as $value) {
-                if(!empty($value['slug'])) {
-                    (!empty($value['topic'])) ? array_push($array, $this->add($value['slug'], $value['topic'])) : $array;
-                    (!empty($value['topic'])) ? array_push($array, $this->add($value['slug'], $value['filename'])) : $array;
+                if(!empty($value['slug']) && !empty($value['topic'])) {
+                    array_push($array, $this->add($value['slug'], $value['topic']));
+                    array_push($array, $this->add($value['slug'], $value['filename']));
                 }
                 foreach($this->getPageData($value['slug']) as $page) {
-                    (!empty($page['v1'])) ? array_push($array,$this->add($value['slug'], $page['v1'])) : $array;
-                    (!empty($page['v2'])) ? array_push($array,$this->add($value['slug'], $page['v2'])) : $array;
-                    (!empty($page['v3'])) ? array_push($array,$this->add($value['slug'], $page['v3'])) : $array;
-                    (!empty($page['v4'])) ? array_push($array,$this->add($value['slug'], $page['v4'])) : $array;
+                    for ($i = 1; $i <= 4; $i++) {
+                        if (!empty($page["v$i"])) {
+                            array_push($array, $this->add($value['slug'], $page["v$i"]));
+                        }
+                    }
                 }
             }
         }
         $this->disconnect('json/search.json',$array);
     }
     
-    public function add($id, $content)
+    public function add($slug, $content)
     {
         return [
-                    'slug' => $id,
+                    'slug' => $slug,
                     'content' => $content
                 ];
     }

--- a/src/views/page/page.php
+++ b/src/views/page/page.php
@@ -47,7 +47,7 @@ if (!is_null($topics)) {
                     $x = 0;
                     $i = 0;
                     foreach($allpages as $page) {
-                        if ($page['slug'] == $_SESSION['page_id']) {
+                        if ($page['slug'] == $_SESSION['page_slug']) {
                             $i = $x;
                         }
                         $x++;


### PR DESCRIPTION
## Summary
- rename `$id` variables to `$slug` and build URLs directly
- improve backup asset fetch logic
- rename slug functions in `PageModel`
- replace ternaries with loops in search indexing
- change session key from `page_id` to `page_slug`

## Testing
- `php -l src/controller/FormPageController.php`
- `for f in src/forms/AddSectionForm.php src/forms/BackupsForms.php src/forms/DeletePageForm.php src/forms/InsertSectionForm.php src/forms/ModifySectionForm.php src/forms/PublishPageForm.php src/forms/RemoveSectionForm.php src/forms/SearchForm.php src/forms/UpdatePageForm.php src/forms/VersionForms.php src/forms/VersionSelectForm.php src/model/BackupsModel.php src/model/PageModel.php src/model/SearchModel.php src/views/page/page.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_686929577fcc83289d893d6fe00ef19f