### PR TITLE
Simplify version save redirect

### DIFF
--- a/src/forms/AddSectionForm.php
+++ b/src/forms/AddSectionForm.php
@@ -21,7 +21,7 @@ class AddSectionForm extends MakeupForm
 
     public function create()
     {
-        $id = $_SESSION['page_slug'];
+        $slug = $_SESSION['page_slug'];
         $options = $this->doc->getOptions();
 
         $form = new Form;
@@ -57,9 +57,9 @@ class AddSectionForm extends MakeupForm
         	if (isset($values['options']) && isset($values['option_content'])) {
         	    
                 $file = $values['file'];
-                $file_path = $this->doc->upload($file, $this->pageModel->getPhpPath($id));
+                $file_path = $this->doc->upload($file, $this->pageModel->getPhpPath($slug));
 
-                    if(isset($id)) {
+                    if(isset($slug)) {
                     $data = ['key' => $values['options'], 'v1' => '', 'v2' => ''];
                     switch ($values['options']) {
                         case 'title':
@@ -71,8 +71,8 @@ class AddSectionForm extends MakeupForm
                             $data['v2'] = $values['option_content'];
                             break;
                     }
-                    $this->pageModel->addPageData($id, $data);
-                    header('Location:'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+                    $this->pageModel->addPageData($slug, $data);
+                    header('Location:'.$this->pageModel->getTopic($slug).'/'.$this->pageModel->getFilename($slug));
         			exit;
         	    } else {
     				$this->msg->error(T::trans('Sorry something didn\'t work!'),BASE_URL.'page/add-section');

--- a/src/forms/DeletePageForm.php
+++ b/src/forms/DeletePageForm.php
@@ -19,17 +19,17 @@ class DeletePageForm extends MakeupForm
 
     public function delete()
     {
-        $id = $_SESSION['page_slug'];
-        $uPath = $this->pageModel->getPhpPath($id);
-        $data = $this->pageModel->getPageData($id);
+        $slug = $_SESSION['page_slug'];
+        $uPath = $this->pageModel->getPhpPath($slug);
+        $data = $this->pageModel->getPageData($slug);
     
         foreach ($data as $fields) {
             if ($fields['key'] == 'image') { (file_exists('json/' . $fields['v1'])) ? unlink('json/' . $fields['v1']) : NULL; }
         }
     
     
-        (file_exists($this->pageModel->getPhpPath($id))) ? unlink($this->pageModel->getPhpPath($id)) : NULL;
-        (file_exists($this->pageModel->getJsonPath($id))) ? unlink($this->pageModel->getJsonPath($id)) : NULL;
+        (file_exists($this->pageModel->getPhpPath($slug))) ? unlink($this->pageModel->getPhpPath($slug)) : NULL;
+        (file_exists($this->pageModel->getJsonPath($slug))) ? unlink($this->pageModel->getJsonPath($slug)) : NULL;
     
         if (isset($_SESSION['Active']) && isset($_SESSION['page_slug'])) {
             if ($uPath == 'json/doc-pht/home.php') {
@@ -57,7 +57,7 @@ class DeletePageForm extends MakeupForm
         }
         
         if (!file_exists($uPath)) {
-            $this->pageModel->remove($id);
+            $this->pageModel->remove($slug);
             header("Location:/doc.php");
         }
     }

--- a/src/forms/InsertSectionForm.php
+++ b/src/forms/InsertSectionForm.php
@@ -21,8 +21,8 @@ class InsertSectionForm extends MakeupForm
 
     public function create()
     {
-        $id = $_SESSION['page_slug'];
-        $uPath = $this->pageModel->getPhpPath($id);
+        $slug = $_SESSION['page_slug'];
+        $uPath = $this->pageModel->getPhpPath($slug);
         $options = $this->doc->getOptions();
 
         $form = new Form;
@@ -60,9 +60,9 @@ class InsertSectionForm extends MakeupForm
         	if (isset($values['options']) && isset($values['option_content'])) {
         	    
                 $file = $values['file'];
-                $file_path = $this->doc->upload($file, $this->pageModel->getPhpPath($id));
+                $file_path = $this->doc->upload($file, $this->pageModel->getPhpPath($slug));
 
-                    if(isset($id)) {
+                    if(isset($slug)) {
                     $data = ['key' => $values['options'], 'v1' => '', 'v2' => ''];
                     switch ($values['options']) {
                         case 'title':
@@ -74,8 +74,8 @@ class InsertSectionForm extends MakeupForm
                             $data['v2'] = $values['option_content'];
                             break;
                     }
-                    $this->pageModel->insertPageData($id, $rowIndex, $b_or_a, $data);
-                    header('Location:'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+                    $this->pageModel->insertPageData($slug, $rowIndex, $b_or_a, $data);
+                    header('Location:'.$this->pageModel->getTopic($slug).'/'.$this->pageModel->getFilename($slug));
         			exit;
         	    } else {
     				$this->msg->error(T::trans('Sorry something didn\'t work!'));

--- a/src/forms/ModifySectionForm.php
+++ b/src/forms/ModifySectionForm.php
@@ -21,13 +21,13 @@ class ModifySectionForm extends MakeupForm
 
     public function create()
     {
-        $id = $_SESSION['page_slug'];
+        $slug = $_SESSION['page_slug'];
         $options = $this->doc->getOptions();
 
         $form = new Form;
         $form->onRender[] = [$this, 'bootstrap4'];
 
-        $page = $this->pageModel->getPageData($id);
+        $page = $this->pageModel->getPageData($slug);
 
         if(isset($_GET['id'])) {
             $rowIndex = $_GET['id'];
@@ -83,9 +83,9 @@ class ModifySectionForm extends MakeupForm
         	if (!empty($values)) {
         	    
                 $file = $values['file'];
-                $file_path = $this->doc->upload($file, $this->pageModel->getPhpPath($id));
+                $file_path = $this->doc->upload($file, $this->pageModel->getPhpPath($slug));
 
-                    if(isset($id)) {
+                    if(isset($slug)) {
                     $data = ['key' => $values['options'], 'v1' => '', 'v2' => ''];
                     switch ($values['options']) {
                         case 'title':
@@ -97,8 +97,8 @@ class ModifySectionForm extends MakeupForm
                             $data['v2'] = $values['option_content'];
                             break;
                     }
-                    $this->pageModel->modifyPageData($id, $rowIndex, $data);
-                    header('Location:'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+                    $this->pageModel->modifyPageData($slug, $rowIndex, $data);
+                    header('Location:'.$this->pageModel->getTopic($slug).'/'.$this->pageModel->getFilename($slug));
         			exit;
         	    } else {
     				$this->msg->error(T::trans('Sorry something didn\'t work!'));

--- a/src/forms/PublishPageForm.php
+++ b/src/forms/PublishPageForm.php
@@ -18,12 +18,12 @@ class PublishPageForm extends MakeupForm
 {
     public function publish()
     {
-        $id = $_SESSION['page_slug'];
+        $slug = $_SESSION['page_slug'];
         $pages = $this->pageModel->connect();
 
         foreach ($pages as $key => $value) {
 
-            if ($value['pages']['slug'] === $id) {
+            if ($value['pages']['slug'] === $slug) {
                 if ($value['pages']['published'] === 0 && $value['pages']['home'] !== 1) {
                     $published = 1;
                 } else {
@@ -44,7 +44,7 @@ class PublishPageForm extends MakeupForm
         }
     
         
-        header('Location:'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+        header('Location:'.$this->pageModel->getTopic($slug).'/'.$this->pageModel->getFilename($slug));
         exit;
     }
 }

--- a/src/forms/RemoveSectionForm.php
+++ b/src/forms/RemoveSectionForm.php
@@ -22,20 +22,20 @@ class RemoveSectionForm extends MakeupForm
     public function create()
     {
 
-        $id = $_SESSION['page_slug'];
+        $slug = $_SESSION['page_slug'];
         
         if(isset($_GET['id'])) {
             $rowIndex = intval($_GET['id']);
         }
         
-        if ($this->pageModel->getPageData($id)[$rowIndex]['key'] == 'image') {
-            unlink('json/' . $this->pageModel->getPageData($id)[$rowIndex]['v1']);
+        if ($this->pageModel->getPageData($slug)[$rowIndex]['key'] == 'image') {
+            unlink('json/' . $this->pageModel->getPageData($slug)[$rowIndex]['v1']);
         }
-        
-        $this->pageModel->removePageData($id, $rowIndex);
-        
-        if(isset($id)) {
-            header('Location:'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+
+        $this->pageModel->removePageData($slug, $rowIndex);
+
+        if(isset($slug)) {
+            header('Location:'.$this->pageModel->getTopic($slug).'/'.$this->pageModel->getFilename($slug));
             exit;
         } else {
     		$this->msg->error(T::trans('Sorry something didn\'t work!'));

--- a/src/forms/UpdatePageForm.php
+++ b/src/forms/UpdatePageForm.php
@@ -22,13 +22,13 @@ class UpdatePageForm extends MakeupForm
     public function create()
     {
 
-        $id = $_SESSION['page_slug'];
+        $slug = $_SESSION['page_slug'];
         $options = $this->doc->getOptions();
 
         $form = new Form;
         $form->onRender[] = [$this, 'bootstrap4'];
 
-        $page = $this->pageModel->getPageData($id);
+        $page = $this->pageModel->getPageData($slug);
 
         $index = 0;
         
@@ -83,7 +83,7 @@ class UpdatePageForm extends MakeupForm
                 
                 if($mapped['options'] == 'image' && $values['file'.$x]->hasFile()) {
                     $file = $mapped['file'];
-                    $file_path = $this->doc->upload($file, $this->pageModel->getPhpPath($id));
+                    $file_path = $this->doc->upload($file, $this->pageModel->getPhpPath($slug));
                 } else {
                     unset($mapped['file']);
                     $file_path = ($mapped['options'] != 'addButton') ? 'json/'.$page[$x]['v1'] : '';
@@ -95,7 +95,7 @@ class UpdatePageForm extends MakeupForm
                     }
                 }
         
-            	    if(isset($id)) {
+                    if(isset($slug)) {
                             $data = ['key' => $mapped['options'], 'v1' => '', 'v2' => ''];
                             switch ($mapped['options']) {
                                 case 'title':
@@ -107,12 +107,12 @@ class UpdatePageForm extends MakeupForm
                                     $data['v2'] = $mapped['option_content'];
                                     break;
                             }
-                            $this->pageModel->modifyPageData($id, $x, $data);
+                            $this->pageModel->modifyPageData($slug, $x, $data);
             	    }
             }
-            header('Location:'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+            header('Location:'.$this->pageModel->getTopic($slug).'/'.$this->pageModel->getFilename($slug));
             exit;
-        } elseif (!isset($id)) {
+        } elseif (!isset($slug)) {
             $this->msg->error(T::trans('Sorry something didn\'t work!'));
         }
 

--- a/src/forms/VersionForms.php
+++ b/src/forms/VersionForms.php
@@ -94,7 +94,10 @@ class VersionForms extends MakeupForm
                 readfile($filename);
                 exit;
             }
-            $this->msg->error(T::trans('Invalid procedure! File not found.'),BASE_URL.'page/'.$this->pageModel->getTopic($_SESSION['page_slug']).'/'.$this->pageModel->getFilename($_SESSION['page_slug']));
+            $this->msg->error(
+                T::trans('Invalid procedure! File not found.'),
+                BASE_URL . 'page/' . $_SESSION['page_slug']
+            );
         } else {
             $this->msg->error(T::trans('Invalid procedure! File not set.'),BASE_URL.'page/'.$this->pageModel->getTopic($_SESSION['page_slug']).'/'.$this->pageModel->getFilename($_SESSION['page_slug']));
         }
@@ -134,11 +137,17 @@ class VersionForms extends MakeupForm
     
     public function save()
     {
-        $id = $_SESSION['page_slug'];
-        if ($this->versionModel->saveVersion($id)) {
-        	$this->msg->success(T::trans('Version saved successfully.'),BASE_URL.'page/'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+        $slug = $_SESSION['page_slug'];
+        if ($this->versionModel->saveVersion($slug)) {
+            $this->msg->success(
+                T::trans('Version saved successfully.'),
+                BASE_URL . 'page/' . $slug
+            );
         } else {
-            $this->msg->error(T::trans('Invalid procedure!'),BASE_URL.'page/'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id));
+            $this->msg->error(
+                T::trans('Invalid procedure!'),
+                BASE_URL . 'page/' . $slug
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- use `$slug` instead of `$id` when saving versions
- redirect using the slug directly
- simplify invalid file redirect
- rename `$id` variables to `$slug` across other forms

## Testing
- `php -l src/forms/AddSectionForm.php`
- `php -l src/forms/DeletePageForm.php`
- `php -l src/forms/InsertSectionForm.php`
- `php -l src/forms/ModifySectionForm.php`
- `php -l src/forms/PublishPageForm.php`
- `php -l src/forms/RemoveSectionForm.php`
- `php -l src/forms/UpdatePageForm.php`


------
https://chatgpt.com/codex/tasks/task_e_68693794a73c83288632f51cbe22e193