### PR TITLE
Remove unused folderEmpty function and run lint

### DIFF
--- a/src/forms/DeletePageForm.php
+++ b/src/forms/DeletePageForm.php
@@ -26,9 +26,4 @@ class DeletePageForm extends MakeupForm
         }
     }
 
-    function folderEmpty($dir) {
-        if (!is_readable($dir)) return null;
-        return count(scandir($dir)) == 2;
-    }
-
 }


### PR DESCRIPTION
## Summary
- remove leftover folderEmpty function from DeletePageForm
- run PHP lint over src

## Testing
- `php -l src/forms/DeletePageForm.php`
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68695c40a9b08328b2ff75af49a6cb0c