### PR TITLE
Fix search command injection and update translations

### DIFF
--- a/src/forms/SearchForm.php
+++ b/src/forms/SearchForm.php
@@ -26,7 +26,7 @@ class SearchForm extends MakeupForm
             $searchthis = $this->sanitizing($_POST["search"]);
 
             $pages = $this->pageModel->connect();
-            $cmd = "grep -R -o -i --include='*.md' " . escapeshellarg($searchthis) . " flat | cut -d: -f1 | sort | uniq -c | sort -nr";
+            $cmd = "grep -R -o -i -F --include='*.md' " . escapeshellarg($searchthis) . " flat | cut -d: -f1 | sort | uniq -c | sort -nr";
             $output = shell_exec($cmd);
             $lines = array_filter(explode("\n", trim($output)));
 

--- a/src/model/SearchModel.php
+++ b/src/model/SearchModel.php
@@ -19,11 +19,6 @@ use DocPHT\Model\PageModel;
 
 class SearchModel extends PageModel
 {
-    public function feed()
-    {
-        // Search indexing handled via grep; no JSON generation required.
-        return true;
-    }
     
     public function add($slug, $content)
     {

--- a/src/translations/zh_CN.php
+++ b/src/translations/zh_CN.php
@@ -133,7 +133,6 @@
         'Search' => '搜索',
         'no match found for ' => '未找到匹配项 ',
         'Matches found' => '找到匹配项',
-        'similarity' => '相似度',
         'Open in New Window?' => '在新窗口中打开？',
         'Add image from file' => '从文件添加图片',
         'Update Password' => '更新密码',


### PR DESCRIPTION
## Summary
- escape grep content search as a fixed string
- drop unused feed function from SearchModel
- remove unused translation key

## Testing
- `php -l src/forms/SearchForm.php` *(fails: command not found)*
- `php -l src/model/SearchModel.php` *(fails: command not found)*
- `php -l src/translations/zh_CN.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869622a3000832895e9388ce81a5edd