### PR TITLE
Fix heading level parsing in DocPHT

### DIFF
--- a/src/controller/FormPageController.php
+++ b/src/controller/FormPageController.php
@@ -43,19 +43,20 @@ class FormPageController extends BaseController
                 $current = '';
                 $anchors = [];
                 foreach ($parts as $part) {
-                        if (preg_match('/^<h[1-6][^>]*>(.*?)<\\/h[1-6]>$/is', trim($part), $m)) {
+                        if (preg_match('/^<h([1-6])[^>]*>(.*?)<\\/h[1-6]>$/is', trim($part), $m)) {
                                 if ($current !== '') {
                                         $segments[] = ['type' => 'markdown', 'text' => $current];
                                         $current = '';
                                 }
-                                $titleText = strip_tags($m[1]);
+                                $level = (int) $m[1];
+                                $titleText = strip_tags($m[2]);
                                 $baseAnchor = preg_replace('/[ %\/#]/', '-', strtolower($titleText));
                                 $anchor = $baseAnchor;
                                 $counter = 2;
                                 while (in_array($anchor, $anchors, true)) {
                                         $anchor = $baseAnchor . '-' . $counter++;
                                 }
-                                $segments[] = ['type' => 'title', 'text' => $titleText, 'anchor' => $anchor];
+                                $segments[] = ['type' => 'title', 'text' => $titleText, 'anchor' => $anchor, 'level' => $level];
                                 $anchors[] = $anchor;
                         } else {
                                 $current .= $part;
@@ -70,7 +71,7 @@ class FormPageController extends BaseController
                 $values = [];
                 foreach ($segments as $segment) {
                         if ($segment['type'] === 'title') {
-                                $values[] = $html->title($segment['text'], $segment['anchor']);
+                                $values[] = $html->title($segment['text'], $segment['anchor'], $segment['level']);
                         } else {
                                 $values[] = $html->markdown($segment['text']);
                         }

--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -148,12 +148,13 @@ class DocPHT {
      *
      * @return string
      */
-    public function title(string $title, string $anchorLinkID = null)
+    public function title(string $title, string $anchorLinkID = null, int $level = 2)
     {
+       $level = max(1, min(6, $level));
        if (isset($anchorLinkID)) {
-        return '<tr><td><h2 class="mt-3 mb-3" id="'.$anchorLinkID.'">'.$title.' </h2></td></tr>';
+        return '<tr><td><h'.$level.' class="mt-3 mb-3" id="'.$anchorLinkID.'">'.$title.'</h'.$level.'></td></tr>';
        }
-       return '<tr><td><h2 class="mt-3 mb-3">'.$title.'  </h2></td></tr>';
+       return '<tr><td><h'.$level.' class="mt-3 mb-3">'.$title.'</h'.$level.'></td></tr>';
     }
 
 


### PR DESCRIPTION
## Summary
- preserve heading level when rendering Markdown
- update DocPHT::title to support custom heading levels

## Testing
- `php -l src/controller/FormPageController.php`
- `php -l src/lib/DocPHT.php`
- `jshint public/assets/js/add-section-upload.js`


------
https://chatgpt.com/codex/tasks/task_e_686f37a433448328b3272f829e2d52eb