### PR TITLE
Handle spaces in docpht image paths

### DIFF
--- a/public/assets/js/add-section-upload.js
+++ b/public/assets/js/add-section-upload.js
@@ -36,7 +36,8 @@
                 dataType: 'json'
             }).done(function(res){
                 if (res.path) {
-                    insertAtCursor($textarea[0], '\n![](' + res.path + ')');
+                    var path = res.path.replace(/ /g, '+');
+                    insertAtCursor($textarea[0], '\n![](' + path + ')');
                 }
             }).always(function(){
                 $input.val('');

--- a/src/model/PageModel.php
+++ b/src/model/PageModel.php
@@ -263,7 +263,7 @@ class PageModel
         }
         $dir = dirname($path);
         $base = basename($path, '.md');
-        preg_match_all('/' . preg_quote($base, '/') . '_\d+\.[A-Za-z0-9]+/i', $markdown, $matches);
+        preg_match_all('/' . str_replace('+', ' ', preg_quote($base, '/')) . '_\d+\.[A-Za-z0-9]+/i', $markdown, $matches);
         $used = isset($matches[0]) ? array_unique($matches[0]) : [];
         foreach (glob($dir . '/' . $base . '_*.{jpg,jpeg,png,gif,svg}', GLOB_BRACE) as $img) {
             if (!in_array(basename($img), $used)) {


### PR DESCRIPTION
## Summary
- encode spaces in uploaded image paths when inserting markdown
- adjust regex in `cleanUnusedImages` to allow encoded spaces

## Testing
- `jshint public/assets/js/add-section-upload.js`
- `php -l src/model/PageModel.php` *(fails: command not found)*
- `php tests/check_translation_keys.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f5850bc708328bfe741f174d1fb4e