### PR TITLE
Fix DocPHT session and admin lookup

### DIFF
--- a/src/core/Helper/DiscuzBridge.php
+++ b/src/core/Helper/DiscuzBridge.php
@@ -26,7 +26,7 @@ class DiscuzBridge
         $_SESSION['PREV_USERAGENT'] = $_SERVER['HTTP_USER_AGENT'];
         $_SESSION['Username'] = $username;
         $_SESSION['Active'] = true;
-        new AccessLogModel()->create($username);
+        (new AccessLogModel())->create($username);
     }
 
     public static function syncSession()

--- a/src/model/AdminModel.php
+++ b/src/model/AdminModel.php
@@ -115,7 +115,10 @@ class AdminModel
     {
         $data = $this->connect();
         $key = array_search($username, array_column($data, 'Username'));
-        
+        if ($key === false || !isset($data[$key]['Admin'])) {
+            return false;
+        }
+
         return $data[$key]['Admin'];
     }
 


### PR DESCRIPTION
## Summary
- fix call chaining when creating access log
- guard against missing user in `checkUserIsAdmin`

## Testing
- `php -l src/core/Helper/DiscuzBridge.php`
- `php -l src/model/AdminModel.php`

------
https://chatgpt.com/codex/tasks/task_e_68711f8f527c8328b76edf1ecda2147d