### PR TITLE
Fix destructive version restore

### DIFF
--- a/src/forms/VersionForms.php
+++ b/src/forms/VersionForms.php
@@ -111,6 +111,9 @@ class VersionForms extends MakeupForm
             $aPath = $this->pageModel->getPath($id);
             $extractDir = dirname($aPath);
 
+            // Backup the current file before restoring
+            $this->versionModel->saveVersion($id);
+
             @unlink($aPath);
 
             $zipData = new \ZipArchive();


### PR DESCRIPTION
## Summary
- backup current version when restoring from zip

## Testing
- `php -l src/forms/VersionForms.php`
- `php tests/check_discuz_login.php`
- `php tests/check_translation_keys.php` *(fails: Missing translations)*

------
https://chatgpt.com/codex/tasks/task_e_6871349287208328acca69303a9b28a0