### PR TITLE
Fix destructive version restore

### DIFF
--- a/src/forms/VersionForms.php
+++ b/src/forms/VersionForms.php
@@ -111,6 +111,15 @@ class VersionForms extends MakeupForm
             $aPath = $this->pageModel->getPath($id);
             $extractDir = dirname($aPath);
 
+            // Backup the current file before restoring
+            if (!$this->versionModel->saveVersion($id)) {
+                $this->msg->error(
+                    T::trans('Invalid procedure!'),
+                    BASE_URL.'page/'.$this->pageModel->getTopic($id).'/'.$this->pageModel->getFilename($id)
+                );
+                return;
+            }
+
             @unlink($aPath);
 
             $zipData = new \ZipArchive();


### PR DESCRIPTION
## Summary
- backup current version when restoring from zip
- abort restore if the backup fails to prevent data loss

## Testing
- `php -l src/forms/VersionForms.php`
- `php tests/check_discuz_login.php`
- `php tests/check_translation_keys.php` *(fails: Missing translations)*

------
https://chatgpt.com/codex/tasks/task_e_6871349287208328acca69303a9b28a0