### PR TITLE
Use timezone-aware datetime for ChangeLogModel

### DIFF
--- a/src/model/ChangeLogModel.php
+++ b/src/model/ChangeLogModel.php
@@ -4,6 +4,8 @@
  */
 namespace DocPHT\Model;
 
+use DocPHT\Lib\DocBuilder;
+
 class ChangeLogModel
 {
     const CHANGELOG = 'json/changelog.json';
@@ -29,7 +31,7 @@ class ChangeLogModel
             'slug' => $slug,
             'username' => $username,
             'action' => $action,
-            'date' => date(DATAFORMAT, time())
+            'date' => DocBuilder::datetimeNow()
         ];
         $excess = count($data) - self::MAX_LOG_ENTRIES;
         if ($excess > 0) {


### PR DESCRIPTION
## Summary
- use `DocBuilder::datetimeNow()` when creating change log entries
- import `DocBuilder` in `ChangeLogModel`

## Testing
- `php -l src/model/ChangeLogModel.php`


------
https://chatgpt.com/codex/tasks/task_e_68715f4e6d2c8328a65f106b75d3c634