### PR TITLE
Enable section editing in DocPHT pages

### DIFF
--- a/public/assets/js/doc-pht.js
+++ b/public/assets/js/doc-pht.js
@@ -185,3 +185,17 @@ if (document.getElementById('rbbackup')) {
     };
 
 }
+
+// Update edit link based on current URL fragment
+if (document.getElementById('sk-update')) {
+    var updateEditLink = function() {
+        var link = document.getElementById('sk-update');
+        if (window.location.hash) {
+            link.setAttribute('href', '/page/update?section=' + encodeURIComponent(window.location.hash.substring(1)));
+        } else {
+            link.setAttribute('href', '/page/update');
+        }
+    };
+    updateEditLink();
+    window.addEventListener('hashchange', updateEditLink);
+}

--- a/public/assets/js/map.shortcut.key.js
+++ b/public/assets/js/map.shortcut.key.js
@@ -39,11 +39,11 @@ $.key("ctrl+alt+a", function() {
 });
 
 $.key("ctrl+alt+e", function() {
-    document.getElementById("sk-add").click();
+    document.getElementById("sk-update").click();
 });
 
 $.key("ctrl+alt+u", function() {
-    document.getElementById("sk-update").click();
+    document.getElementById("sk-add").click();
 });
 
 $.key("ctrl+alt+d", function() {

--- a/src/controller/FormPageController.php
+++ b/src/controller/FormPageController.php
@@ -89,12 +89,13 @@ class FormPageController extends BaseController
                 echo '<script src="/public/assets/js/add-section-upload.js"></script>';
 	}
 
-	public function getUpdatePageForm()
-	{
-		$form = $this->updatePageForm->create();
-		$this->view->load('Update page','form-page/update_page.php', ['form' => $form]);
+        public function getUpdatePageForm()
+        {
+                $anchor = $_GET['section'] ?? null;
+                $form = $this->updatePageForm->create($anchor);
+                $this->view->load('Update page','form-page/update_page.php', ['form' => $form]);
                 echo '<script src="/public/assets/js/add-section-upload.js"></script>';
-	}
+        }
 	
 	public function getDeletePageForm()
 	{

--- a/src/views/admin/settings.php
+++ b/src/views/admin/settings.php
@@ -218,11 +218,11 @@
                             <td><?= $t->trans('Settings'); ?></td>
                         </tr>
                         <tr>
-                            <td><span class="badge badge-secondary">ctrl+alt+e</span></td>
+                            <td><span class="badge badge-secondary">ctrl+alt+u</span></td>
                             <td><?= $t->trans('Add new item to the page'); ?></td>
                         </tr>
                         <tr>
-                            <td><span class="badge badge-secondary">ctrl+alt+u</span></td>
+                            <td><span class="badge badge-secondary">ctrl+alt+e</span></td>
                             <td><?= $t->trans('Update the current page'); ?></td>
                         </tr>
                         <tr>


### PR DESCRIPTION
## Summary
- support editing a single section of a DocPHT page
- swap update/add keyboard shortcuts
- adjust settings page description
- update edit button link when browsing anchored sections
- fix nullable anchor parameter and newline

## Testing
- `jshint public/assets/js/doc-pht.js public/assets/js/map.shortcut.key.js`
- `php -l src/controller/FormPageController.php`
- `php -l src/forms/UpdatePageForm.php`
- `php -l src/model/PageModel.php`
- `php -l src/views/admin/settings.php`
- `php tests/check_translation_keys.php`


------
https://chatgpt.com/codex/tasks/task_e_68717336c3e483288e0069decf655abb