### PR TITLE
Support editing individual DocPHT sections

### DIFF
--- a/public/assets/js/doc-pht.js
+++ b/public/assets/js/doc-pht.js
@@ -54,14 +54,12 @@ $(document).ready(function () {
     updateEditLink();
     $(window).on('hashchange', updateEditLink);
 
-$(document).ready(function () {
-        var sidebar = getCookie('sidebar');
-        if (sidebar === 'in') {
-            $('#sidebar, #content').toggleClass('active');
-            $('.collapse.in').toggleClass('in');
-            $('a[aria-expanded=true]').attr('aria-expanded', 'false');
-        }
-    });
+    var sidebar = getCookie('sidebar');
+    if (sidebar === 'in') {
+        $('#sidebar, #content').toggleClass('active');
+        $('.collapse.in').toggleClass('in');
+        $('a[aria-expanded=true]').attr('aria-expanded', 'false');
+    }
 
     $('#sidebarCollapse').on('click', function () {
         var sidebar = getCookie('sidebar');

--- a/public/assets/js/doc-pht.js
+++ b/public/assets/js/doc-pht.js
@@ -34,11 +34,25 @@ function setCookie(cname, cvalue, exdays) {
   document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
 }
 
+function updateEditLink() {
+    var link = document.getElementById('sk-update');
+    if (!link) { return; }
+    var hash = window.location.hash.substring(1);
+    if (hash) {
+        link.href = '/page/update?section=' + encodeURIComponent(hash);
+    } else {
+        link.href = '/page/update';
+    }
+}
+
 
 $(document).ready(function () {
     $("#sidebar").mCustomScrollbar({
         theme: "minimal"
     });
+
+    updateEditLink();
+    $(window).on('hashchange', updateEditLink);
 
 $(document).ready(function () {
         var sidebar = getCookie('sidebar');

--- a/src/controller/FormPageController.php
+++ b/src/controller/FormPageController.php
@@ -14,6 +14,7 @@
 namespace DocPHT\Controller;
 
 use Instant\Core\Controller\BaseController;
+use DocPHT\Core\Helper\AnchorHelper;
 
 class FormPageController extends BaseController
 {
@@ -50,14 +51,8 @@ class FormPageController extends BaseController
                                 }
                                 $level = (int) $m[1];
                                 $titleText = strip_tags($m[2]);
-                                $baseAnchor = preg_replace('/[ %\/#]/', '-', strtolower($titleText));
-                                $anchor = $baseAnchor;
-                                $counter = 2;
-                                while (in_array($anchor, $anchors, true)) {
-                                        $anchor = $baseAnchor . '-' . $counter++;
-                                }
+                                $anchor = AnchorHelper::generate($titleText, $anchors);
                                 $segments[] = ['type' => 'title', 'text' => $titleText, 'anchor' => $anchor, 'level' => $level];
-                                $anchors[] = $anchor;
                         } else {
                                 $current .= $part;
                         }

--- a/src/core/Helper/AnchorHelper.php
+++ b/src/core/Helper/AnchorHelper.php
@@ -1,0 +1,24 @@
+<?php
+namespace DocPHT\Core\Helper;
+
+class AnchorHelper
+{
+    /**
+     * Generate a unique anchor for a heading title.
+     *
+     * @param string $title Heading text
+     * @param array<string> $existing Anchors already used
+     * @return string Anchor
+     */
+    public static function generate(string $title, array &$existing): string
+    {
+        $base = preg_replace('/[ %\/#]/', '-', strtolower($title));
+        $anchor = $base;
+        $counter = 2;
+        while (in_array($anchor, $existing, true)) {
+            $anchor = $base . '-' . $counter++;
+        }
+        $existing[] = $anchor;
+        return $anchor;
+    }
+}

--- a/src/forms/UpdatePageForm.php
+++ b/src/forms/UpdatePageForm.php
@@ -3,6 +3,7 @@ namespace DocPHT\Form;
 
 use Nette\Forms\Form;
 use DocPHT\Core\Translator\T;
+use DocPHT\Core\Helper\AnchorHelper;
 
 class UpdatePageForm extends MakeupForm
 {
@@ -18,13 +19,7 @@ class UpdatePageForm extends MakeupForm
         foreach ($matches[0] as $i => $full) {
             $level = strlen($matches[1][$i][0]);
             $title = $matches[2][$i][0];
-            $base = preg_replace('/[ %\/#]/', '-', strtolower($title));
-            $an = $base;
-            $c = 2;
-            while (in_array($an, $anchors, true)) {
-                $an = $base . '-' . $c++;
-            }
-            $anchors[] = $an;
+            $an = AnchorHelper::generate($title, $anchors);
             $sections[] = ['anchor' => $an, 'level' => $level, 'offset' => $full[1]];
         }
 

--- a/src/forms/UpdatePageForm.php
+++ b/src/forms/UpdatePageForm.php
@@ -6,17 +6,63 @@ use DocPHT\Core\Translator\T;
 
 class UpdatePageForm extends MakeupForm
 {
+    private function splitSection(string $markdown, string $anchor)
+    {
+        if ($anchor === '') {
+            return [$markdown, '', ''];
+        }
+
+        preg_match_all('/^(#{1,6})\s*(.+)$/m', $markdown, $matches, PREG_OFFSET_CAPTURE);
+        $anchors = [];
+        $sections = [];
+        foreach ($matches[0] as $i => $full) {
+            $level = strlen($matches[1][$i][0]);
+            $title = $matches[2][$i][0];
+            $base = preg_replace('/[ %\/#]/', '-', strtolower($title));
+            $an = $base;
+            $c = 2;
+            while (in_array($an, $anchors, true)) {
+                $an = $base . '-' . $c++;
+            }
+            $anchors[] = $an;
+            $sections[] = ['anchor' => $an, 'level' => $level, 'offset' => $full[1]];
+        }
+
+        $len = strlen($markdown);
+        foreach ($sections as $i => $sec) {
+            if ($sec['anchor'] !== $anchor) {
+                continue;
+            }
+            $start = $sec['offset'];
+            $end = $len;
+            for ($j = $i + 1; $j < count($sections); $j++) {
+                if ($sections[$j]['level'] <= $sec['level']) {
+                    $end = $sections[$j]['offset'];
+                    break;
+                }
+            }
+            $before = substr($markdown, 0, $start);
+            $section = substr($markdown, $start, $end - $start);
+            $after = substr($markdown, $end);
+            return [$section, $before, $after];
+        }
+
+        return [$markdown, '', ''];
+    }
+
     public function create()
     {
         $slug = $_SESSION['page_slug'];
+        $section = $_GET['section'] ?? '';
         $markdown = $this->pageModel->get($slug) ?? '';
+        list($editText) = $this->splitSection($markdown, $section);
 
         $form = new Form;
         $form->onRender[] = [$this, 'bootstrap4'];
         $form->addGroup(T::trans('Update page'));
         $form->addTextArea('markdown', T::trans('Enter content'))
             ->setHtmlAttribute('rows', 20)
-            ->setDefaultValue($markdown);
+            ->setDefaultValue($editText);
         $form->addUpload('image', T::trans('Add image from file'))
             ->setRequired(false)
             ->addRule(Form::MIME_TYPE, 'File must be JPEG, PNG, GIF or SVG.', ['image/jpeg','image/gif','image/png','image/svg+xml'])
@@ -26,9 +72,21 @@ class UpdatePageForm extends MakeupForm
 
         if ($form->isSuccess()) {
             $values = $form->getValues();
-            if ($this->pageModel->put($slug, $values['markdown'])) {
-                $this->pageModel->cleanUnusedImages($slug, $values['markdown']);
-                header('Location:/page/' . $slug);
+            $current = $this->pageModel->get($slug) ?? '';
+            if ($section !== '') {
+                list(, $before, $after) = $this->splitSection($current, $section);
+                $newMarkdown = $before . $values['markdown'] . $after;
+            } else {
+                $newMarkdown = $values['markdown'];
+            }
+
+            if ($this->pageModel->put($slug, $newMarkdown)) {
+                $this->pageModel->cleanUnusedImages($slug, $newMarkdown);
+                $location = '/page/' . $slug;
+                if ($section !== '') {
+                    $location .= '#' . rawurlencode($section);
+                }
+                header('Location:' . $location);
                 exit;
             } else {
                 $this->msg->error(T::trans("Sorry something didn't work!"), BASE_URL . 'page/update');


### PR DESCRIPTION
## Summary
- tweak doc-pht.js so the Update link follows the current hash
- allow UpdatePageForm to edit only a selected section of a page

## Testing
- `php -l src/forms/UpdatePageForm.php`
- `jshint public/assets/js/doc-pht.js`
- `php tests/check_translation_keys.php`

------
https://chatgpt.com/codex/tasks/task_e_68717872e85083289f1c344f99d343da