### PR TITLE
Integrate upstream modthreadkey fix

### DIFF
--- a/source/module/forum/forum_viewthread.php
+++ b/source/module/forum/forum_viewthread.php
@@ -1275,7 +1275,7 @@ function viewthread_procpost($post, $lastvisit, $ordertype, $maxposition = 0) {
 						$post['message'] = preg_replace("/\s?\[page\]\s?/is", '', $post['message']);
 					}
 					if($_GET['cp'] != 'all' && strpos($post['message'], '[/index]') === FALSE && empty($_GET['threadindex']) && !$messageindex) {
-						$_G['forum_posthtml']['footer'][$post['pid']] .= '<div id="threadpage"></div><script type="text/javascript" reload="1">show_threadpage('.$post['pid'].', '.$cp.', '.count($messagearray).', '.($_GET['from'] == 'preview' ? '1' : '0').');</script>';
+$_G['forum_posthtml']['footer'][$post['pid']] .= '<div id="threadpage"></div><script type="text/javascript" reload="1">show_threadpage(' . $post['pid'] . ', ' . $cp . ', ' . count($messagearray) . ', ' . ($_GET['from'] == 'preview' ? '1' : '0') . ', \'' . (isset($_GET['modthreadkey']) ? $_GET['modthreadkey'] : '') . '\');</script>';
 					}
 				}
 			}

--- a/static/js/forum_viewthread.js
+++ b/static/js/forum_viewthread.js
@@ -498,31 +498,31 @@ function display_blocked_post() {
 	$('hiddenposts').innerHTML+='<div id="postlistreply" class="pl">'+postlistreply+'</div>';
 }
 
-function show_threadpage(pid, current, maxpage, ispreview) {
+function show_threadpage(pid, current, maxpage, ispreview, modthreadkey) {
 	if(!$('threadpage') || typeof tid == 'undefined') {
 		return;
 	};
-	var clickvalue = function (page) {
-		return 'ajaxget(\'forum.php?mod=viewthread&tid=' + tid + '&viewpid=' + pid + '&cp=' + page + (ispreview ? '&from=preview' : '') + '\', \'post_' + pid + '\', \'ajaxwaitid\');';
+    var clickvalue = function (page, modthreadkey) {
+        return 'ajaxget(\'forum.php?mod=viewthread&tid=' + tid + '&viewpid=' + pid + '&cp=' + page + (modthreadkey ? ('&modthreadkey=' + modthreadkey) : '') + (ispreview ? '&from=preview' : '') + '\', \'post_' + pid + '\', \'ajaxwaitid\');';
 	};
 	var pstart = current - 1;
 	pstart = pstart < 1 ? 1 : pstart;
 	var pend = current + 1;
 	pend = pend > maxpage ? maxpage : pend;
 	var s = '<div class="cm pgs mtm mbm cl"><div class="pg">';
-	if(pstart > 1) {
-		s += '<a href="javascript:;" onclick="' + clickvalue(1) + '">1 ...</a>';
+        if(pstart > 1) {
+                s += '<a href="javascript:;" onclick="' + clickvalue(1, modthreadkey) + '">1 ...</a>';
 	}
 	for(i = pstart;i <= pend;i++) {
-		s += i == current ? '<strong>' + i + '</strong>' : '<a href="javascript:;" onclick="' + clickvalue(i)+ '">' + i + '</a>';
+                s += i == current ? '<strong>' + i + '</strong>' : '<a href="javascript:;" onclick="' + clickvalue(i, modthreadkey)+ '">' + i + '</a>';
 	}
 	if(pend < maxpage) {
-		s += '<a href="javascript:;" onclick="' + clickvalue(maxpage)+ '">... ' + maxpage + '</a>';
+                s += '<a href="javascript:;" onclick="' + clickvalue(maxpage, modthreadkey)+ '">... ' + maxpage + '</a>';
 	}
 	if(current < maxpage) {
-		s += '<a href="javascript:;" onclick="' + clickvalue(current + 1) + '" class="nxt">'+lng['next_page']+'</a>';
+                s += '<a href="javascript:;" onclick="' + clickvalue(current + 1, modthreadkey) + '" class="nxt">'+lng['next_page']+'</a>';
 	}
-       s += '<a href="javascript:;" onclick="' + clickvalue('all') + '">'+lng['view_all']+'</a>';
+       s += '<a href="javascript:;" onclick="' + clickvalue('all', modthreadkey) + '">'+lng['view_all']+'</a>';
 	s += '</div></div>';
 	$('threadpage').innerHTML = s;
 }


### PR DESCRIPTION
## Summary
- pass modthreadkey through viewthread preview page
- include modthreadkey when rendering threadpage pagination

## Testing
- `php -l source/module/forum/forum_viewthread.php`
- `jshint static/js/forum_viewthread.js`
- `php tests/check_translation_keys.php`


------
https://chatgpt.com/codex/tasks/task_e_6871a6b574bc8328ba126852c2b38db6