### PR TITLE
Integrate mobile tag management

### DIFF
--- a/static/image/mobile/style.css
+++ b/static/image/mobile/style.css
@@ -71,6 +71,7 @@ a.button {color:var(--dz-FC-fff)}
 .btn_pn_red {background-color:var(--dz-BG-2);color:var(--dz-FC-fff)}
 .btn_pn_orange {background-color:var(--dz-BG-3);color:var(--dz-FC-fff)}
 .btn_pn_green {background-color:var(--dz-BG-4);color:var(--dz-FC-fff)}
+.btn_pn_cancel {background-color:var(--dz-BG-6);color:var(--dz-FC-fff)}
 input[type="reset"]::-moz-focus-inner,
 input[type="button"]::-moz-focus-inner,
 input[type="submit"]::-moz-focus-inner,
@@ -244,6 +245,9 @@ select {-moz-appearance:none;}
 .f_c, .f_c a {color: var(--dz-FC-ccc);}
 .f_d, .f_d a {color: var(--dz-FC-ddd);}
 .f_9, .f_9 a {color: var(--dz-FC-999);}
+.txt_a_l {text-align:left;}
+.txt_a_c {text-align:center;}
+.txt_a_r {text-align:right;}
 .b_t {border-top:1px solid var(--dz-BOR-ed) !important;}
 .b_b {border-bottom:1px solid var(--dz-BOR-ed) !important}
 .b_a {border:1px solid var(--dz-BOR-ed) !important;}
@@ -440,7 +444,8 @@ select {-moz-appearance:none;}
 .jump_c {padding:100px 15px;background-color:var(--dz-BG-0);border-top:1px solid var(--dz-BOR-ed);border-bottom:1px solid var(--dz-BOR-ed);margin-top:10px;font-size:15px}
 .jump_c p {line-height:26px}
 .jump_c p .grey {color:var(--dz-FC-999)}
-.tip {width:300px;text-align:center;background-color:var(--dz-BG-0);border:1px solid var(--dz-BOR-ed);border-radius:6px}
+.tip {width:300px;margin:auto;text-align:center;background-color:var(--dz-BG-0);border:1px solid var(--dz-BOR-ed);border-radius:6px}
+.tip .tit {font-weight: 700;}
 .tip dt {padding:25px 20px;line-height:30px;font-size:14px}
 .tip dt.mpt {margin:15px;padding:10px;background-color:var(--dz-BG-5);border-radius:4px}
 .tip dt.mpt .pt {min-height:96px}
@@ -1370,3 +1375,4 @@ details summary { color:blue; cursor:pointer; }
 /* 标签 .ptg */
 .ptg:before { content: "\f14a"; font-family: dzicon; font-size: 16px; line-height: 14px; color: #7DA0CC; }
     .ptg a { color: {HIGHLIGHTLINK}; }
+

--- a/template/default/touch/forum/post_editor_attribute.htm
+++ b/template/default/touch/forum/post_editor_attribute.htm
@@ -128,7 +128,8 @@
 				<ul class="cl">
 					<li class="flex-box mli">
 						<div class="tit">{lang post_tag}:</div>
-						<div class="flex input"><input type="text" class="px vm" size="60" id="tags" name="tags" value="{$postinfo[tag] or ''}" /></div>
+<div class="flex-2 input"><input type="text" class="px vm" size="60" id="tags" name="tags" value="{$postinfo[tag] or ''}" /></div>
+<div class="flex txt_a_r cl"><a href="forum.php?mod=tag" class="dialog button p5">{lang choosetag}</a></div>
 					</li>
 					<li class="mtit p10">
 						<p class="xg1">{lang posttag_comment}</p>

--- a/template/default/touch/forum/tag.htm
+++ b/template/default/touch/forum/tag.htm
@@ -1,0 +1,84 @@
+<!--{template common/header}-->
+<!--{if ($op == 'search')}-->
+<!--{if $taglist}-->
+<!--{loop $taglist $var}-->
+<li class="mli"><a href="javascript:;" onclick="if(this.className == 'xi2') { window.onbeforeunload = null; parent.document.getElementById('tags').value += parent.document.getElementById('tags').value == '' ? '$var[tagname]' : ',$var[tagname]'; doane(); this.className += ' marked'; }" class="xi2">$var[tagname]</a></li>
+<!--{/loop}-->
+<!--{else}-->
+<div class="emp">{lang none_tag}</div>
+<!--{/if}-->
+<!--{elseif ($op == 'set')}-->
+<!--{elseif ($op == 'manage')}-->
+<div class="tip loginbox loginpop p5" id="floatlayout_topicadmin">
+<h2 class="tit" id="return_tag">{lang post_tag}</h2>
+<dt class="cl">
+<p>
+<input type="text" name="tags" id="tags" class="px pxbg" value="$tags" size="60" />
+<input type="hidden" name="tid" id="tid" value="$_GET['tid']" />
+</p>
+<p><span class="xg1 txt_a_l z">{lang posttag_comment}</span></p>
+</dt>
+<ul class="post_box cl">
+<!--{if $recent_use_tag}-->
+<li class="mli">{lang recent_use_tag}</li>
+<li class="mli">
+<!--{eval $tagi = 0;}-->
+<!--{loop $recent_use_tag $var}-->
+<!--{if $tagi}-->, <!--{/if}--><a href="javascript:;" class="xi2" onclick="getID('tags').value == '' ? getID('tags').value += '$var' : getID('tags').value += ',$var';">$var</a>
+<!--{eval $tagi++;}-->
+<!--{/loop}-->
+</li>
+<!--{/if}-->
+</ul>
+<div class="mb10 cl"></div>
+<dd>
+<button type="button" name="search_button" class="pn button z" value="false" onclick="tagset();"><strong>{lang submit}</strong></button>
+<button type="button" id="closebtn" class="pn button btn_pn_red y" onclick="popup.close();"><strong>{lang close}</strong></button>
+</dd>
+</div>
+<!--{else}-->
+<div class="tip loginbox loginpop p5" id="floatlayout_topicadmin">
+<h2 class="tit" id="return_tagsearch">{lang choosetag}</h2>
+<dt class="cl">
+<div class="flex-box cl">
+<div class="flex-3"><input type="text" name="searchkey" id="searchkey" class="px pxbg p5" value="$searchkey" size="60" /></div>
+<div class="flex mb5"><button type="button" name="search_button" class="pn button vm" value="false" onclick="tagsearch();"><em>{lang search}</em></button></div>
+</div>
+<p><span class="xg1 txt_a_l z">{lang tag_search}</span></p>
+</dt>
+<ul id="taglistarea" class="post_box cl">
+</ul>
+<div class="mb10 cl"></div>
+<dd>
+<button type="button" class="pn button" id="closebtn" onclick="popup.close();"><strong>{lang close}</strong></button>
+</dd>
+</div>
+<!--{/if}-->
+<script type="text/javascript">
+function tagsearch() {
+getID('taglistarea').innerHTML = '';
+var searchkey = getID('searchkey').value;
+var url = 'forum.php?mod=tag&op=search&inajax=1&searchkey='+searchkey;
+var x = new Ajax();
+x.get(url, function(s){
+if(s) {
+getID('taglistarea').innerHTML = s;
+}
+});
+}
+
+function tagset() {
+var tags = getID('tags').value;
+var tid = getID('tid').value;
+tags = BROWSER.ie && document.charset == 'utf-8' ? encodeURIComponent(tags) : tags;
+var url = 'forum.php?mod=tag&op=set&inajax=1&tags='+tags+'&tid='+tid+'&formhash={FORMHASH}';
+var x = new Ajax();
+x.get(url, function(s){
+if(s) {
+hideWindow('$_GET[handlekey]');
+window.location.reload();
+}
+});
+}
+</script>
+<!--{template common/footer}-->


### PR DESCRIPTION
## Summary
- support cancel-style buttons and alignment helpers in mobile style
- improve `.tip` appearance
- allow selecting tags when posting from mobile
- add tag management template for mobile

## Testing
- `php tests/check_translation_keys.php`

------
https://chatgpt.com/codex/tasks/task_e_6871aa369d68832883b2963fd1761be3