### PR TITLE
Remove legacy language placeholder

### DIFF
--- a/template/default/touch/forum/post_editor_attribute.htm
+++ b/template/default/touch/forum/post_editor_attribute.htm
@@ -131,9 +131,6 @@
 <div class="flex-2 input"><input type="text" class="px vm" size="60" id="tags" name="tags" value="{$postinfo[tag] or ''}" /></div>
 <div class="flex txt_a_r cl"><a href="forum.php?mod=tag" class="dialog button p5">{lang choosetag}</a></div>
 					</li>
-					<li class="mtit p10">
-						<p class="xg1">{lang posttag_comment}</p>
-					</li>
 				</ul>
 			</div>
 		<!--{/if}-->

--- a/template/default/touch/forum/tag.htm
+++ b/template/default/touch/forum/tag.htm
@@ -16,7 +16,6 @@
 <input type="text" name="tags" id="tags" class="px pxbg" value="$tags" size="60" />
 <input type="hidden" name="tid" id="tid" value="$_GET['tid']" />
 </p>
-<p><span class="xg1 txt_a_l z">{lang posttag_comment}</span></p>
 </dt>
 <ul class="post_box cl">
 <!--{if $recent_use_tag}-->


### PR DESCRIPTION
## Summary
- remove unused `{lang posttag_comment}` reference in tag editor templates

## Testing
- `grep -n posttag_comment -r template/default/touch/forum | head`

------
https://chatgpt.com/codex/tasks/task_e_6871ae7fac9883289f7c00463d1f6ae1