### PR TITLE
Fix conditional class attribute in DocPHT links

### DIFF
--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -51,15 +51,20 @@ class MediaWikiParsedown extends ParsedownPlus
 
             $newPage = !file_exists('page/' . $topic . '/' . $filename . '.md');
             $url = $newPage ? '/page/create?mainfilename=' . urlencode($filename) : '/page/' . $topic . '/' . $filename;
+
+            $attributes = [
+                'href' => $url . $fragment,
+            ];
+            if ($newPage) {
+                $attributes['class'] = 'new';
+            }
+
             $Inline = array(
                 'extent' => strlen($matches[0]),
                 'element' => array(
                     'name' => 'a',
                     'text' => $filename . $fragment,
-                    'attributes' => array(
-                        'href' => $url . $fragment,
-                        'class' => $newPage ? 'new' : '',
-                    ),
+                    'attributes' => $attributes,
                 ),
             );
             return $Inline;


### PR DESCRIPTION
## Summary
- ensure the `class` attribute is only added for new pages

## Testing
- `php -l src/lib/DocPHT.php`

------
https://chatgpt.com/codex/tasks/task_e_6871fa2d78e483289a1a19c3b3ce9955