### PR TITLE
Refactor bbcode replacements

### DIFF
--- a/static/js/bbcode.js
+++ b/static/js/bbcode.js
@@ -140,9 +140,9 @@ function bbcode2html(str) {
 		}
 	}
 
-	for(var i = 0; i <= DISCUZCODE['num']; i++) {
-		str = str.replace("[\tDISCUZ_CODE_" + i + "\t]", DISCUZCODE['html'][i]);
-	}
+       str = str.replace(/\[\tDISCUZ_CODE_(\d+)\t\]/g, function(match, index) {
+               return DISCUZCODE['html'][parseInt(index, 10)];
+       });
 
 	if(!allowhtml || !fetchCheckbox('htmlon')) {
 		str = str.replace(/(^|>)([^<]+)(?=<|$)/ig, function($1, $2, $3) {
@@ -422,9 +422,9 @@ function html2bbcode(str) {
 
 	str = str.replace(/<[\/\!]*?[^<>]*?>/ig, '');
 
-	for(var i = 0; i <= DISCUZCODE['num']; i++) {
-		str = str.replace("[\tDISCUZ_CODE_" + i + "\t]", DISCUZCODE['html'][i]);
-	}
+       str = str.replace(/\[\tDISCUZ_CODE_(\d+)\t\]/g, function(match, index) {
+               return DISCUZCODE['html'][parseInt(index, 10)];
+       });
 	str = clearcode(str);
 
 	return preg_replace(['&nbsp;', '&lt;', '&gt;', '&amp;'], [' ', '<', '>', '&'], str);
@@ -508,10 +508,9 @@ function litag(listoptions, text) {
 }
 
 function parsecode(text) {
-	DISCUZCODE['num']++;
-	text = text.replace(/\$/ig, '$$$$');
-	DISCUZCODE['html'][DISCUZCODE['num']] = '<div class="blockcode"><blockquote>' + htmlspecialchars(text) + '</blockquote></div>';
-	return "[\tDISCUZ_CODE_" + DISCUZCODE['num'] + "\t]";
+       DISCUZCODE['num']++;
+       DISCUZCODE['html'][DISCUZCODE['num']] = '<div class="blockcode"><blockquote>' + htmlspecialchars(text) + '</blockquote></div>';
+       return "[\tDISCUZ_CODE_" + DISCUZCODE['num'] + "\t]";
 }
 
 function parsestyle(tagoptions, prepend, append) {

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1579,7 +1579,6 @@ function codetag(text, br) {
        if(br > 0 && typeof wysiwyg != 'undefined' && wysiwyg) {
                text = text.replace(/<br[^\>]*>/ig, '\n');
        }
-       text = text.replace(/\$/ig, '$$$$');
        DISCUZCODE.html[DISCUZCODE.num] = '[code]' + text + '[/code]';
        return '[\tDISCUZ_CODE_' + DISCUZCODE.num + '\t]';
 }


### PR DESCRIPTION
## Summary
- replace placeholder replacements using functions
- remove unnecessary `$` escaping in `parsecode`
- drop unused dollar escaping from `codetag`

## Testing
- `jshint static/js/bbcode.js static/js/common.js`

------
https://chatgpt.com/codex/tasks/task_e_6871e6ccb12083288f6f9bd67ebf499e