### PR TITLE
Add copy button plugin for highlight.js

### DIFF
--- a/src/views/partial/footer.php
+++ b/src/views/partial/footer.php
@@ -31,7 +31,10 @@
     <script src="/public/assets/js/clipboard.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
     <script src="//unpkg.com/highlightjs-lean/dist/lean.min.js"></script>
+    <script src="//unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.js"></script>
+    <link rel="stylesheet" href="//unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.css">
     <script>
+        hljs.addPlugin(new CopyButtonPlugin());
         hljs.highlightAll();
     </script>
     <!-- bootstrap select in form -->

--- a/src/views/partial/head.php
+++ b/src/views/partial/head.php
@@ -21,6 +21,7 @@
     <link rel="stylesheet" href="/public/assets/css/scrollbar.min.css">
     <!-- Syntax highlighting -->
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/styles/default.min.css">
+    <link rel="stylesheet" href="//unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.css">
     <!-- Most popular and easiest to use icon set -->
     <link rel="stylesheet" href="/public/assets/css/font-awesome.min.css">
     <!-- Stylesheet fro bootstrap select in form -->


### PR DESCRIPTION
## Summary
- load highlightjs-copy CSS in the page header
- enable CopyButtonPlugin alongside highlight.js scripts

## Testing
- `php -l src/views/partial/head.php`
- `php -l src/views/partial/footer.php`
- `php tests/check_translation_keys.php`

------
https://chatgpt.com/codex/tasks/task_e_68726ee2ef588328b6dcd649e2a58e4a