### PR TITLE
Fix math block trailing Markdown parsing

### DIFF
--- a/src/lib/DocPHT.php
+++ b/src/lib/DocPHT.php
@@ -72,16 +72,26 @@ class MediaWikiParsedown extends ParsedownPlus
     }
 
     // Fix greedy LaTeX block parsing by allowing closing $$ anywhere on the line
+    // and parsing any trailing Markdown after the closing delimiter
     protected function blockMath($Line)
     {
-        if (preg_match('/^\\$\\$(.*)$/', $Line['text'], $matches)) {
-            $Block = array(
-                'char' => $Line['text'][0],
-                'markup' => $Line['text'],
-            );
+        if (substr($Line['text'], 0, 2) === '$$') {
+            $Block = [
+                'char' => '$',
+                'markup' => '',
+            ];
 
-            if (strpos($matches[1], '$$') !== false) {
+            $closePos = strpos($Line['text'], '$$', 2);
+
+            if ($closePos !== false) {
+                $Block['markup'] = substr($Line['text'], 0, $closePos + 2);
+                $remainder = substr($Line['text'], $closePos + 2);
+                if (trim($remainder) !== '') {
+                    $Block['markup'] .= "\n" . $this->line($remainder);
+                }
                 $Block['complete'] = true;
+            } else {
+                $Block['markup'] = $Line['text'];
             }
 
             return $Block;
@@ -99,8 +109,12 @@ class MediaWikiParsedown extends ParsedownPlus
             unset($Block['interrupted']);
         }
 
-        if (strpos($Line['text'], '$$') !== false) {
-            $Block['markup'] .= "\n" . $Line['text'];
+        if (($pos = strpos($Line['text'], '$$')) !== false) {
+            $Block['markup'] .= "\n" . substr($Line['text'], 0, $pos + 2);
+            $remainder = substr($Line['text'], $pos + 2);
+            if (trim($remainder) !== '') {
+                $Block['markup'] .= "\n" . $this->line($remainder);
+            }
             $Block['complete'] = true;
             return $Block;
         }


### PR DESCRIPTION
## Summary
- handle trailing Markdown after closing `$$` in math blocks

## Testing
- `php -l src/lib/DocPHT.php`

------
https://chatgpt.com/codex/tasks/task_e_687430bbce1883289512fc5186cc6576