### PR TITLE
Use exclusive lock for DocPHT add-section

### DIFF
--- a/src/model/PageModel.php
+++ b/src/model/PageModel.php
@@ -185,7 +185,7 @@ class PageModel
         if (!is_dir(dirname($path))) {
             mkdir(dirname($path), 0777, true);
         }
-        $result = file_put_contents($path, $content) !== false;
+        $result = file_put_contents($path, $content, LOCK_EX) !== false;
         if ($result) {
             $log = new ChangeLogModel();
             $username = $_SESSION['Username'] ?? 'Unknown';


### PR DESCRIPTION
## Summary
- lock file when saving DocPHT page sections

## Testing
- `php -l src/model/PageModel.php`
- `php tests/check_translation_keys.php`

------
https://chatgpt.com/codex/tasks/task_e_68743dd7b048832880c5137f204b7e67