### PR TITLE
Add docpht CSS rule for final block spacing

### DIFF
--- a/public/assets/css/doc-pht.dark.css
+++ b/public/assets/css/doc-pht.dark.css
@@ -13,6 +13,13 @@ p {
     color: #f5f5f5;
 }
 
+p:last-child,
+ul:last-child,
+ol:last-child,
+blockquote:last-child {
+    margin-bottom: 0;
+}
+
 a,
 a:hover,
 a:focus {

--- a/public/assets/css/doc-pht.light.css
+++ b/public/assets/css/doc-pht.light.css
@@ -8,6 +8,13 @@ p {
     line-height: 1.7em;
 }
 
+p:last-child,
+ul:last-child,
+ol:last-child,
+blockquote:last-child {
+    margin-bottom: 0;
+}
+
 a,
 a:hover,
 a:focus {


### PR DESCRIPTION
## Summary
- remove bottom margin on last child paragraphs, lists, and blockquotes in DocPHT styles

## Testing
- `php -v`

------
https://chatgpt.com/codex/tasks/task_e_6874abda78e48328a9551fc3cc9328da