### PR TITLE
Fix nested math regex

### DIFF
--- a/tests/findtex_node.js
+++ b/tests/findtex_node.js
@@ -1,0 +1,42 @@
+const text = '$$\\begin{pmatrix}a&b\\\\c&d\\end{pmatrix}$$';
+
+function quotePattern(p){
+  return p.replace(/([.*+?^${}()|[\]\/\\])/g,'\\$1');
+}
+
+function findTeX(text){
+  const startRegex = /(\$\$)|\\begin\s*\{([^}]*)\}/g;
+  function findEnd(start){
+    if(start[1]){
+      const endPattern = new RegExp(`${quotePattern('$$')}|\\\\(?:[a-zA-Z]|.)|[{}]`,'g');
+      endPattern.lastIndex = start.index + start[0].length;
+      let match, braces=0;
+      while((match=endPattern.exec(text))){
+        if(match[0]==='$$' && braces===0){
+          return text.slice(start.index, match.index+2);
+        }else if(match[0]==='{'){braces++;}else if(match[0]==='}'&&braces){braces--;}
+      }
+    } else {
+      const env=start[2];
+      const pattern=new RegExp(`\\\\(?:begin|end)\\s*\\{${quotePattern(env)}\\}|\\\\(?:[a-zA-Z]|.)|[{}]`,'g');
+      pattern.lastIndex=start.index+start[0].length;
+      let match,braces=0,nested=0;
+      while((match=pattern.exec(text))){
+        if(match[0].startsWith('\\begin')){nested++;}
+        else if(match[0].startsWith('\\end') && nested){nested--;}
+        else if(match[0].startsWith('\\end') && nested===0){
+          return text.slice(start.index, match.index + match[0].length);
+        }else if(match[0]==='{'){braces++;}else if(match[0]==='}'&&braces){braces--;}
+      }
+    }
+    return null;
+  }
+  let m; const items=[]; startRegex.lastIndex=0;
+  while((m=startRegex.exec(text))){
+    const block=findEnd(m);
+    if(block){items.push(block); startRegex.lastIndex = m.index + block.length;}
+  }
+  return items;
+}
+
+console.log(findTeX(text));


### PR DESCRIPTION
## Summary
- tweak delimiter sort order to prioritize `$$`
- support nested `\begin` environments in latex parsing
- add NodeJS demo to validate TeX detection

## Testing
- `jshint public/assets/js/latex.js`
- `jshint tests/findtex_node.js`
- `node tests/findtex_node.js`

------
https://chatgpt.com/codex/tasks/task_e_68790d9b48bc83289f2836cd9608f3ec