### PR TITLE
Fix messagecutstr BBCode handling

### DIFF
--- a/source/function/function_post.php
+++ b/source/function/function_post.php
@@ -583,7 +583,7 @@ function messagecutstr($message, $length = 0, $dot = ' ...', $html = 0) {
 	}
 	$language = lang('forum/misc');
 	loadcache(array('bbcodes_display', 'bbcodes', 'smileycodes', 'smilies', 'smileytypes', 'domainwhitelist'));
-	$bbcodes = 'b|i|u|p|color|backcolor|size|font|align|list|indent|float|table|tr|td';
+       $bbcodes = 'b|i|u|p|color|backcolor|size|font|align|list|indent|float|table|tr|td|th';
        $bbcodesclear = 'tikz|asy|email|code|free|img|swf|attach|media|audio|groupid|payto'.(!empty($_G['cache']['bbcodes_display'][$_G['groupid']]) ? '|'.implode('|', array_keys($_G['cache']['bbcodes_display'][$_G['groupid']])) : '');
 	$str = preg_replace(array(
 			"/\[hide=?\d*\](.*?)\[\/hide\]/is",


### PR DESCRIPTION
## Summary
- include `th` BBCode in `messagecutstr`

## Testing
- `php -l source/function/function_post.php`


------
https://chatgpt.com/codex/tasks/task_e_687c42399968832898f287d07578aef6