### PR TITLE
Fix feed full post retrieval

### DIFF
--- a/source/module/forum/forum_ajax.php
+++ b/source/module/forum/forum_ajax.php
@@ -703,9 +703,6 @@ if($_GET['action'] == 'checkusername') {
 	$feed = $thread = array();
 	if($tid) {
 		$thread = C::t('forum_thread')->fetch_thread($tid);
-		if(empty($_G['setting']['followforumid']) || $thread['fid'] != $_G['setting']['followforumid']) {
-			$flag = 0;
-		}
 		if($flag) {
 			$post = C::t('forum_post')->fetch_post($thread['posttableid'], $pid);
 			if($thread['tid'] != $post['tid']) {


### PR DESCRIPTION
## Summary
- Removed a forum-specific check to let feed requests retrieve full posts even when they come from different forums

## Testing
- `php -l source/module/forum/forum_ajax.php`

------
https://chatgpt.com/codex/tasks/task_e_6886779aa15083288d992c9e879f6a23