### PR TITLE
Remove redundant footer stylesheet

### DIFF
--- a/src/views/partial/footer.php
+++ b/src/views/partial/footer.php
@@ -32,7 +32,6 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
     <script src="//unpkg.com/highlightjs-lean/dist/lean.min.js"></script>
     <script src="//unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.js"></script>
-    <link rel="stylesheet" href="//unpkg.com/highlightjs-copy/dist/highlightjs-copy.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js"></script>
     <script>
         class PlaygroundPlugin {


### PR DESCRIPTION
## Summary
- remove duplicate `highlightjs-copy` CSS include from the footer

## Testing
- `php -l src/views/partial/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_688685ddf8108328a6640893a3ac39c7