### PR TITLE
Remove unused tagoffcheck variable

### DIFF
--- a/source/include/post/post_editpost.php
+++ b/source/include/post/post_editpost.php
@@ -76,8 +76,7 @@ if(!submitcheck('editsubmit')) {
 	$urloffcheck = $postinfo['parseurloff'] ? 'checked="checked"' : '';
 	$smileyoffcheck = $postinfo['smileyoff'] == 1 ? 'checked="checked"' : '';
 	$codeoffcheck = $postinfo['bbcodeoff'] == 1 ? 'checked="checked"' : '';
-	$tagoffcheck = $postinfo['htmlon'] & 2 ? 'checked="checked"' : '';
-	$htmloncheck = $postinfo['htmlon'] & 1 ? 'checked="checked"' : '';
+        $htmloncheck = $postinfo['htmlon'] & 1 ? 'checked="checked"' : '';
 	if(!$isfirstpost) {
 		$_G['group']['allowimgcontent'] = 0;
 	}

--- a/source/include/post/post_newthread.php
+++ b/source/include/post/post_newthread.php
@@ -80,8 +80,7 @@ if(!submitcheck('topicsubmit', 0, $seccodecheck, $secqaacheck)) {
 
 	$isfirstpost = 1;
 	$allownoticeauthor = 1;
-	$tagoffcheck = '';
-	$showthreadsorts = !empty($sortid) || getglobal('forum/threadsorts/required') && empty($special);
+        $showthreadsorts = !empty($sortid) || getglobal('forum/threadsorts/required') && empty($special);
 	if(empty($sortid) && empty($special) && getglobal('forum/threadsorts/required') && $_G['forum']['threadsorts']['types']) {
 		$tmp = array_keys($_G['forum']['threadsorts']['types']);
 		$sortid = $tmp[0];


### PR DESCRIPTION
## Summary
- delete unused `tagoffcheck` variable from post editing and new thread handlers

## Testing
- `php -l source/include/post/post_editpost.php`
- `php -l source/include/post/post_newthread.php`


------
https://chatgpt.com/codex/tasks/task_e_688d7edce3f48328bdf2d6b5028ba72f