### PR TITLE
Fix missing tags on new threads

### DIFF
--- a/source/class/model/model_forum_thread.php
+++ b/source/class/model/model_forum_thread.php
@@ -141,7 +141,7 @@ class model_forum_thread extends discuz_model
 			'isgroup' => $this->param['isgroup'],
                        'replycredit' => $this->param['replycredit'],
                        'closed' => $this->param['closed'] ? 1 : 0,
-                       'tags' => $this->param['tagstr']
+                       'tags' => ''
                );
 		$this->tid = C::t('forum_thread')->insert($newthread, true);
 		C::t('forum_newthread')->insert(array(
@@ -181,9 +181,11 @@ class model_forum_thread extends discuz_model
 		$this->param['parseurloff'] = !empty($this->param['parseurloff']);
 		$this->param['htmlon'] = $this->group['allowhtml'] && !empty($this->param['htmlon']) ? 1 : 0;
 		$this->param['usesig'] = !empty($this->param['usesig']) && $this->group['maxsigsize'] ? 1 : 0;
-		$class_tag = new tag();
-		$this->param['tagstr'] = $class_tag->add_tag($this->param['tags'], $this->tid, 'tid');
-
+               $class_tag = new tag();
+               $this->param['tagstr'] = $class_tag->add_tag($this->param['tags'], $this->tid, 'tid');
+               if ($this->param['tagstr']) {
+                       C::t('forum_thread')->update($this->tid, array('tags' => $this->param['tagstr']));
+               }
 
 		$this->param['pinvisible'] = $this->param['modnewthreads'] ? -2 : (empty($this->param['save']) ? 0 : -3);
 		$this->param['message'] = preg_replace('/\[attachimg\](\d+)\[\/attachimg\]/is', '[attach]\1[/attach]', $this->param['message']);


### PR DESCRIPTION
## Summary
- ensure new thread processing updates thread's tag field after generating tags
- ensure tidy tag processing by adjusting sequence and calling add_tag with the real tid.


## Testing
- `php -l source/class/model/model_forum_thread.php`

------
https://chatgpt.com/codex/tasks/task_e_688d86f3e76c8328bce6d16d438a9291