### PR TITLE
refactor: remove unused tag variable

### DIFF
--- a/source/class/model/model_forum_thread.php
+++ b/source/class/model/model_forum_thread.php
@@ -182,10 +182,7 @@ class model_forum_thread extends discuz_model
 		$this->param['htmlon'] = $this->group['allowhtml'] && !empty($this->param['htmlon']) ? 1 : 0;
 		$this->param['usesig'] = !empty($this->param['usesig']) && $this->group['maxsigsize'] ? 1 : 0;
                $class_tag = new tag();
-               $this->param['tagstr'] = $class_tag->add_tag($this->param['tags'], $this->tid, 'tid');
-               if ($this->param['tagstr']) {
-                       C::t('forum_thread')->update($this->tid, array('tags' => $this->param['tagstr']));
-               }
+               C::t('forum_thread')->update($this->tid, array('tags' => $class_tag->add_tag($this->param['tags'], $this->tid, 'tid')));
 
 		$this->param['pinvisible'] = $this->param['modnewthreads'] ? -2 : (empty($this->param['save']) ? 0 : -3);
 		$this->param['message'] = preg_replace('/\[attachimg\](\d+)\[\/attachimg\]/is', '[attach]\1[/attach]', $this->param['message']);


### PR DESCRIPTION
## Summary
- remove intermediate `$this->param['tagstr']` variable when updating thread tags

## Testing
- `php -l source/class/model/model_forum_thread.php`
- `php tests/check_discuz_login.php` *(fails: Failed to open stream: No such file or directory)*
- `php tests/check_translation_keys.php`
- `php tests/test_math_trailing_link.php` *(fails: Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688d904b18488328b7708ba96747811a