### PR TITLE
Avoid unnecessary global fetches in error log

### DIFF
--- a/source/class/discuz/discuz_error.php
+++ b/source/class/discuz/discuz_error.php
@@ -338,15 +338,16 @@ EOT;
 		return $message;
 	}
 
-	public static function write_error_log($message) {
+       public static function write_error_log($message) {
+                global $_G;
 
-		$message = discuz_error::clear($message);
-		$time = time();
-		$file =  DISCUZ_ROOT.'./data/log/'.date("Ym").'_errorlog.php';
-		$hash = md5($message);
+                $message = discuz_error::clear($message);
+                $time = time();
+                $file =  DISCUZ_ROOT.'./data/log/'.date("Ym").'_errorlog.php';
+                $hash = md5($message);
 
-		$uid = getglobal('uid');
-		$ip = getglobal('clientip');
+                $uid = $_G['uid'];
+                $ip = $_G['clientip'];
 
 		$user = '<b>User:</b> uid='.intval($uid).'; IP='.$ip.'; RIP:'.$_SERVER['REMOTE_ADDR'];
 		$uri = 'Request: '.discuz_error::clear($_SERVER['REQUEST_URI']);


### PR DESCRIPTION
## Summary
- Access global uid and client IP directly in `discuz_error::write_error_log`

## Testing
- `php -l source/class/discuz/discuz_error.php`
- `php tests/check_discuz_login.php` *(fails: Failed opening required 'vendor/autoload.php')*
- `php tests/check_translation_keys.php`
- `php tests/test_math_trailing_link.php` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_688dadf7b8b88328b272552434cadf72