### PR TITLE
Guard attachnew param access

### DIFF
--- a/source/class/extend/extend_thread_image.php
+++ b/source/class/extend/extend_thread_image.php
@@ -79,12 +79,12 @@ class extend_thread_image extends extend_thread_base {
 	}
   public function after_newreply() {
           $this->mobile_upload();
-          ($this->group['allowpostattach'] || $this->group['allowpostimage']) && ($_GET['attachnew'] || $this->param['special'] == 2 && $_GET['tradeaid']) && updateattach($this->thread['displayorder'] == -4 || $this->param['modnewreplies'], $this->thread['tid'], $this->pid, $_GET['attachnew']);
+        ($this->group['allowpostattach'] || $this->group['allowpostimage']) && (!empty($_GET['attachnew']) || $this->param['special'] == 2 && $_GET['tradeaid']) && updateattach($this->thread['displayorder'] == -4 || $this->param['modnewreplies'], $this->thread['tid'], $this->pid, $_GET['attachnew']);
   }
 
   public function before_editpost($parameters) {
          global $_G;
-         $attachupdate = !empty($_GET['delattachop']) || ($this->group['allowpostattach'] || $this->group['allowpostimage']) && ($_GET['attachnew'] || $parameters['special'] == 2 && $_GET['tradeaid'] || $parameters['special'] == 4 && $_GET['activityaid']);
+        $attachupdate = !empty($_GET['delattachop']) || ($this->group['allowpostattach'] || $this->group['allowpostimage']) && (!empty($_GET['attachnew']) || $parameters['special'] == 2 && $_GET['tradeaid'] || $parameters['special'] == 4 && $_GET['activityaid']);
          if($attachupdate) {
                  updateattach($this->thread['displayorder'] == -4 || $_G['forum_auditstatuson'], $this->thread['tid'], $this->post['pid'], $_GET['attachnew'], $_GET['attachupdate'], $this->post['authorid']);
          }


### PR DESCRIPTION
## Summary
- prevent undefined index warnings by checking `attachnew` GET parameter exists in reply and edit handlers


------
https://chatgpt.com/codex/tasks/task_e_688db42f251883289f358dbb537765ee