### PR TITLE
Fix mobile reply cache when thread list is missing

### DIFF
--- a/source/plugin/mobile/api/4/sub_sendreply.php
+++ b/source/plugin/mobile/api/4/sub_sendreply.php
@@ -16,8 +16,11 @@ $newmessage = preg_replace('/<\/*.*?>|&nbsp;|\r\n|\[attachimg\].*?\[\/attachimg\
 $newmessage = messagecutstr($newmessage, 100);
 
 $key = C::t('#mobile#mobile_wsq_threadlist')->fetch($_G['tid']);
-$posts = is_array($key) ? dunserialize($key['svalue']) : array();
-$posts = is_array($posts) ? $posts : array();
+$posts = array();
+if (is_array($key) && isset($key['svalue']) && $key['svalue'] !== '') {
+        $posts = dunserialize($key['svalue']);
+        $posts = is_array($posts) ? $posts : array();
+}
 
 if (trim($newmessage) != '' && !getstatus($thread['status'], 2)) {
 	if (!$posts) {


### PR DESCRIPTION
## Summary
- avoid undefined `svalue` and null unserialize warnings in mobile reply cache

The reply workflow triggers `sub_sendreply.php` through the `post_mobile_message` hook: Discuz! invokes `base_plugin_mobile_forum::post_mobile_message`, and `plugin_mobile_forum::post_mobile_message` then includes `sub_sendreply.php` after a successful reply


------
https://chatgpt.com/codex/tasks/task_e_688e8c952b2c83288fdc03d4549dceb5