### PR TITLE
fix: make floating editor responsive

### DIFF
--- a/template/default/common/common.css
+++ b/template/default/common/common.css
@@ -1318,7 +1318,7 @@ body, input, button, select { font: {FONTSIZE} {FONT}; color: {TABLETEXT}; }
 		.tedt .area { padding: 4px; background: {WRAPBG}; zoom: 1; }
 		.tedt .pt { width: 100%; margin-right: 0; padding: 0 !important; border: none; background: {WRAPBG} no-repeat center; }
 			.tedt .pt:focus { outline: none; -moz-box-shadow: none; }
-	.m_c .tedt { width: 600px; }
+       .m_c .tedt { width: 100%; max-width: 600px; }
 
 /* 表情 */
 .sllt { padding: 10px 5px 5px !important; }


### PR DESCRIPTION
## Summary
- ensure floating editor adapts to small screens by using a flexible width with a maximum of 600px

## Testing
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_68904036894c8328aa9619121bd663d6