### PR TITLE
Ensure parent forum lastpost reflects latest subforum activity

### DIFF
--- a/source/include/cron/cron_security_cleanup_lastpost.php
+++ b/source/include/cron/cron_security_cleanup_lastpost.php
@@ -12,21 +12,35 @@ if(!defined('IN_DISCUZ')) {
 }
 
 $queryf = C::t('forum_forum')->fetch_all_fids();
+$parent_fups = array();
 foreach($queryf as $forum) {
-	$thread = C::t('forum_thread')->fetch_by_fid_displayorder($forum['fid']);
-	$thread['shortsubject'] = cutstr($thread['subject'], 80);
-	$lastpost = "{$thread['tid']}\t{$thread['shortsubject']}\t{$thread['lastpost']}\t{$thread['lastposter']}";
+        if($forum['type'] == 'sub' && !empty($forum['fup'])) {
+                $parent_fups[] = $forum['fup'];
+        }
+}
+
+$parents = array();
+if(!empty($parent_fups)) {
+        $parents = C::t('forum_forum')->fetch_all_info_by_fids(array_unique($parent_fups));
+}
+
+foreach($queryf as $forum) {
+        $thread = C::t('forum_thread')->fetch_by_fid_displayorder($forum['fid']);
+        $thread['shortsubject'] = cutstr($thread['subject'], 80);
+        $lastpost = "{$thread['tid']}\t{$thread['shortsubject']}\t{$thread['lastpost']}\t{$thread['lastposter']}";
 
         C::t('forum_forum')->update($forum['fid'], array('lastpost' => $lastpost));
         if($forum['type'] == 'sub') {
-                $parent = C::t('forum_forum')->fetch_info_by_fid($forum['fup']);
-                $parent_lastpost = 0;
-                if(!empty($parent['lastpost'])) {
-                        $tmp = explode("\t", $parent['lastpost']);
-                        $parent_lastpost = intval($tmp[2]);
-                }
-                if($thread['lastpost'] > $parent_lastpost) {
-                        C::t('forum_forum')->update($forum['fup'], array('lastpost' => $lastpost));
+                $parent = isset($parents[$forum['fup']]) ? $parents[$forum['fup']] : null;
+                if($parent) {
+                        $parent_lastpost = 0;
+                        if(!empty($parent['lastpost'])) {
+                                $tmp = explode("\t", $parent['lastpost']);
+                                $parent_lastpost = intval($tmp[2]);
+                        }
+                        if($thread['lastpost'] > $parent_lastpost) {
+                                C::t('forum_forum')->update($forum['fup'], array('lastpost' => $lastpost));
+                        }
                 }
         }
 }

--- a/source/include/cron/cron_security_cleanup_lastpost.php
+++ b/source/include/cron/cron_security_cleanup_lastpost.php
@@ -17,9 +17,17 @@ foreach($queryf as $forum) {
 	$thread['shortsubject'] = cutstr($thread['subject'], 80);
 	$lastpost = "{$thread['tid']}\t{$thread['shortsubject']}\t{$thread['lastpost']}\t{$thread['lastposter']}";
 
-	C::t('forum_forum')->update($forum['fid'], array('lastpost' => $lastpost));
-	if($forum['type'] == 'sub') {
-		C::t('forum_forum')->update($forum['fup'], array('lastpost' => $lastpost));
-	}
+        C::t('forum_forum')->update($forum['fid'], array('lastpost' => $lastpost));
+        if($forum['type'] == 'sub') {
+                $parent = C::t('forum_forum')->fetch_info_by_fid($forum['fup']);
+                $parent_lastpost = 0;
+                if(!empty($parent['lastpost'])) {
+                        $tmp = explode("\t", $parent['lastpost']);
+                        $parent_lastpost = intval($tmp[2]);
+                }
+                if($thread['lastpost'] > $parent_lastpost) {
+                        C::t('forum_forum')->update($forum['fup'], array('lastpost' => $lastpost));
+                }
+        }
 }
 ?>


### PR DESCRIPTION
## Summary
- Avoid overwriting parent forum lastpost unless subforum activity is newer

## Testing
- `php -l source/include/cron/cron_security_cleanup_lastpost.php`
- `php tests/check_discuz_login.php`
- `php tests/check_translation_keys.php`
- `php tests/test_math_trailing_link.php`


------
https://chatgpt.com/codex/tasks/task_e_689e02c4933c832ea8183237b73359f8