### PR TITLE
fix: guard against missing post element

### DIFF
--- a/chat/PusherChatWidget.js
+++ b/chat/PusherChatWidget.js
@@ -63,8 +63,11 @@
           const pageNumberElement=document.querySelector('div.pg>strong');
           const pageNumber=pageNumberElement?pageNumberElement.textContent.trim():1;
           if(data.tid==tid && data.page==pageNumber){
-            ajaxget(`forum.php?mod=viewthread&tid=${tid}&viewpid=${data.pid}`, 'post_new', 'ajaxwaitid', '', null,function() {
+            ajaxget(`forum.php?mod=viewthread&tid=${tid}&viewpid=${data.pid}`, 'post_new', 'ajaxwaitid', '', null, function() {
               const postNew = $('post_new');
+              if (!postNew) {
+                return;
+              }
               postNew.id = `post_${data.pid}`;
               postNew.style.display = '';
               if (typeof MathJax.typesetPromise === 'function') {


### PR DESCRIPTION
## Summary
- prevent TypeError when 'post_new' element is absent in PusherChatWidget

## Testing
- `jshint chat/PusherChatWidget.js` *(fails: ES6 syntax not enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68b03d8aebcc832e8a36d942e3bb8450