### PR TITLE
Remove duplicate smilies cache entry

### DIFF
--- a/forum.php
+++ b/forum.php
@@ -28,7 +28,7 @@ $modcachelist = array(
 			'heats', 'historyposts', 'onlinerecord', 'userstats', 'diytemplatenameforum'),
 	'forumdisplay'	=> array('smilies', 'announcements_forum', 'globalstick', 'forums',
 			'onlinelist', 'forumstick', 'threadtable_info', 'threadtableids', 'diytemplatenameforum'),
-	'viewthread'	=> array('smilies', 'smileytypes', 'forums', 'usergroups', 'bbcodes', 'smilies', 'custominfo', 'groupicon',
+	'viewthread'	=> array('smilies', 'smileytypes', 'forums', 'usergroups', 'bbcodes', 'custominfo', 'groupicon',
 			'threadtableids', 'threadtable_info', 'posttable_info', 'diytemplatenameforum'),
 	'redirect'	=> array('threadtableids', 'threadtable_info', 'posttable_info'),
 	'post'		=> array('bbcodes_display', 'bbcodes', 'smileycodes', 'smilies', 'smileytypes',


### PR DESCRIPTION
## Summary
- clean up viewthread cache list by removing duplicate `smilies` entry

## Testing
- `php -l forum.php`


------
https://chatgpt.com/codex/tasks/task_e_68b526fda650832eab6dfdb847b26914