### PR TITLE
fix: restore mobile PM and notification checks

### DIFF
--- a/template/default/touch/common/footer.htm
+++ b/template/default/touch/common/footer.htm
@@ -54,6 +54,19 @@
 	</a>
 </div>
 <!--{/if}-->
+<!--{if !$_G['setting']['bbclosed'] && empty($_G['member']['freeze'] && $_G['member']['groupid'] != 5)}-->
+<!--{if $_G[uid] && !isset($_G['cookie']['checkpm'])}-->
+<script type="text/javascript" src="home.php?mod=spacecp&ac=pm&op=checknewpm&rand=$_G[timestamp]"></script>
+<!--{/if}-->
+
+<!--{if $_G[uid] && helper_access::check_module('follow') && !isset($_G['cookie']['checkfollow'])}-->
+<script type="text/javascript" src="home.php?mod=spacecp&ac=follow&op=checkfeed&rand=$_G[timestamp]"></script>
+<!--{/if}-->
+
+<!--{if !isset($_G['cookie']['sendmail'])}-->
+<script type="text/javascript" src="home.php?mod=misc&ac=sendmail&rand=$_G[timestamp]"></script>
+<!--{/if}-->
+<!--{/if}-->
 </body>
 </html>
 <!--{eval updatesession();}-->


### PR DESCRIPTION
## Summary
- load scripts in mobile footer to check new PMs, follow feeds, and pending email notifications

## Testing
- `php -l template/default/touch/common/footer.htm`


------
https://chatgpt.com/codex/tasks/task_e_68b562efe694832e81dc8ee8639e8d93