### PR TITLE
Drop redundant displayorder column from smilies table

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Threads no longer support the legacy stamp and icon features. Drop the related f
 ```sql
 ALTER TABLE `pre_forum_thread` DROP COLUMN `stamp`, DROP COLUMN `icon`;
 ALTER TABLE `pre_forum_threadmod` DROP COLUMN `stamp`;
-ALTER TABLE `pre_common_smiley` DROP COLUMN `type`, DROP COLUMN `typeid`;
+ALTER TABLE `pre_common_smiley` DROP COLUMN `type`, DROP COLUMN `typeid`, DROP COLUMN `displayorder`;
 ALTER TABLE `pre_common_admingroup` DROP COLUMN `allowstampthread`, DROP COLUMN `allowstamplist`;
 ```
 


### PR DESCRIPTION
## Summary
- Drop unnecessary `displayorder` field from `pre_common_smiley` table.

## Testing
- `php tests/check_discuz_login.php`
- `php tests/check_translation_keys.php`
- `php tests/test_math_trailing_link.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5c54053f0832ebb053715abb6b83f