### PR TITLE
Avoid ellipsis in lastpost subject truncation

### DIFF
--- a/source/class/table/table_forum_forum.php
+++ b/source/class/table/table_forum_forum.php
@@ -330,7 +330,7 @@ class table_forum_forum extends discuz_table
 		$subject = str_replace("\t", ' ', $subject);
 		$author = str_replace("\t", ' ', $author);
 		if(function_exists('cutstr')) {
-			$subject = cutstr($subject, 80);
+			$subject = cutstr($subject, 80, '');
 		}
 		return $tid."\t".$subject."\t".$dateline."\t".$author;
 	}


### PR DESCRIPTION
## Summary
- truncate forum lastpost subject without appending ellipsis

## Testing
- `php -l source/class/table/table_forum_forum.php`
- `php tests/check_discuz_login.php`
- `php tests/check_translation_keys.php`
- `php tests/test_math_trailing_link.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6c0e89574832eae659d7fc41c6d04