### PR TITLE
Use update_lastpost helper for forum lastpost writes

### DIFF
--- a/source/admincp/admincp_counter.php
+++ b/source/admincp/admincp_counter.php
@@ -48,8 +48,7 @@ if(submitcheck('forumsubmit', 1)) {
 		C::t('forum_forum')->update($forum['fid'], array('archive' => $archive));
 
 		$thread = C::t('forum_thread')->fetch_by_fid_displayorder($forum['fid']);
-		$subject = $thread['subject'];
-		$lastpost = "{$thread['tid']}\t{$thread['lastpost']}\t{$thread['lastposter']}\t{$subject}";
+		$lastpost = C::t('forum_forum')->build_lastpost_string($thread['tid'], $thread['subject'], $thread['lastpost'], $thread['lastposter']);
 
 		C::t('forum_forum')->update($forum['fid'], array('threads' => $threads, 'posts' => $posts, 'lastpost' => $lastpost));
 	}

--- a/source/class/model/model_forum_thread.php
+++ b/source/class/model/model_forum_thread.php
@@ -242,13 +242,11 @@ class model_forum_thread extends discuz_model
 					C::t('forum_groupuser')->update_counter_for_user($this->member['uid'], $this->forum['fid'], 1);
 				}
 
-				$subject = str_replace("\t", ' ', $this->param['subject']);
-				$lastpost = "$this->tid\t".$subject."\t".TIMESTAMP."\t$author";
-				C::t('forum_forum')->update($this->forum['fid'], array('lastpost' => $lastpost));
+				C::t('forum_forum')->update_lastpost($this->forum['fid'], $this->tid, $this->param['subject'], TIMESTAMP, $author, array(
+					'propagate_parent' => $this->forum['type'] == 'sub',
+					'forum' => $this->forum
+				));
 				C::t('forum_forum')->update_forum_counter($this->forum['fid'], 1, 1, 1);
-				if($this->forum['type'] == 'sub') {
-					C::t('forum_forum')->update($this->forum['fup'], array('lastpost' => $lastpost));
-				}
 			}
 
 			if($this->param['isgroup']) {

--- a/source/class/table/table_forum_forum.php
+++ b/source/class/table/table_forum_forum.php
@@ -339,19 +339,14 @@ class table_forum_forum extends discuz_table
 	 * @param string $subject Thread subject
 	 * @param int $dateline Post dateline timestamp
 	 * @param string $author Post author name
-	 * @param array $options Options: propagate_parent (bool), forum (array), raw (bool)
+	 * @param array $options Options: propagate_parent (bool), forum (array)
 	 * @return string The lastpost string that was stored
 	 */
 	public function update_lastpost($fid, $tid, $subject, $dateline, $author, $options = array()) {
 		$propagate_parent = isset($options['propagate_parent']) ? $options['propagate_parent'] : true;
 		$forum = isset($options['forum']) ? $options['forum'] : null;
-		$raw = isset($options['raw']) ? $options['raw'] : false;
 
-		if($raw) {
-			$lastpost = $tid."\t".$dateline."\t".$author."\t".$subject;
-		} else {
-			$lastpost = $this->build_lastpost_string($tid, $subject, $dateline, $author);
-		}
+		$lastpost = $this->build_lastpost_string($tid, $subject, $dateline, $author);
 
 		$this->update($fid, array('lastpost' => $lastpost));
 

--- a/source/include/cron/cron_security_cleanup_lastpost.php
+++ b/source/include/cron/cron_security_cleanup_lastpost.php
@@ -26,9 +26,8 @@ if(!empty($parent_fups)) {
 
 foreach($queryf as $forum) {
         $thread = C::t('forum_thread')->fetch_by_fid_displayorder($forum['fid']);
-        $lastpost = C::t('forum_forum')->build_lastpost_string($thread['tid'], $thread['subject'], $thread['lastpost'], $thread['lastposter']);
 
-        C::t('forum_forum')->update($forum['fid'], array('lastpost' => $lastpost));
+        C::t('forum_forum')->update_lastpost($forum['fid'], $thread['tid'], $thread['subject'], $thread['lastpost'], $thread['lastposter'], array('forum' => $forum, 'propagate_parent' => false));
         if($forum['type'] == 'sub') {
                 $parent = isset($parents[$forum['fup']]) ? $parents[$forum['fup']] : null;
                 if($parent) {
@@ -38,7 +37,7 @@ foreach($queryf as $forum) {
                                $parent_lastpost = intval($tmp[1]);
                        }
                         if($thread['lastpost'] > $parent_lastpost) {
-                                C::t('forum_forum')->update($forum['fup'], array('lastpost' => $lastpost));
+                                C::t('forum_forum')->update_lastpost($forum['fup'], $thread['tid'], $thread['subject'], $thread['lastpost'], $thread['lastposter'], array('forum' => $parent, 'propagate_parent' => false));
                         }
                 }
         }

--- a/source/include/topicadmin/topicadmin_moderate.php
+++ b/source/include/topicadmin/topicadmin_moderate.php
@@ -341,7 +341,7 @@ if(!submitcheck('modsubmit')) {
 
 
 				C::t('forum_thread')->update($tidsarr, array('lastpost'=>$expiration, 'moderated'=>1), true);
-				C::t('forum_forum')->update($_G['fid'], array('lastpost' => "{$thread['tid']}\t{$thread['subject']}\t$expiration\t{$thread['lastposter']}"));
+				C::t('forum_forum')->update_lastpost($_G['fid'], $thread['tid'], $thread['subject'], $expiration, $thread['lastposter'], array('forum' => $_G['forum'], 'propagate_parent' => $_G['forum']['type'] == 'sub'));
 
 				$_G['forum']['threadcaches'] && deletethreadcaches($moderatetids);
 			} elseif($operation == 'down') {


### PR DESCRIPTION
## Summary
- Replace manual lastpost concatenation in admin counter with build_lastpost_string and single update
- Use update_lastpost for moderation bump operation
- Centralize cron security cleanup on update_lastpost to avoid raw updates
- Restore original indentation in forum counter
- Drop unused `raw` option from update_lastpost helper
- Fix update_lastpost docblock indentation for options parameter
- Fix tab indentation for update_lastpost implementation

## Testing
- `php -l source/admincp/admincp_counter.php`
- `php -l source/include/topicadmin/topicadmin_moderate.php`
- `php -l source/include/cron/cron_security_cleanup_lastpost.php`
- `php -l source/class/model/model_forum_thread.php`
- `php -l source/class/table/table_forum_forum.php`


------
https://chatgpt.com/codex/tasks/task_e_68b707059c6c832eadec403e837d2645