### PR TITLE
Optimize forum counter updates

### DIFF
--- a/source/admincp/admincp_counter.php
+++ b/source/admincp/admincp_counter.php
@@ -45,12 +45,10 @@ if(submitcheck('forumsubmit', 1)) {
 				$archive = 1;
 			}
 		}
-		C::t('forum_forum')->update($forum['fid'], array('archive' => $archive));
-
 		$thread = C::t('forum_thread')->fetch_by_fid_displayorder($forum['fid']);
 		$lastpost = C::t('forum_forum')->build_lastpost_string($thread['tid'], $thread['subject'], $thread['lastpost'], $thread['lastposter']);
 
-		C::t('forum_forum')->update($forum['fid'], array('threads' => $threads, 'posts' => $posts, 'lastpost' => $lastpost));
+		C::t('forum_forum')->update($forum['fid'], array('archive' => $archive, 'threads' => $threads, 'posts' => $posts, 'lastpost' => $lastpost));
 	}
 
 	if($processed) {


### PR DESCRIPTION
## Summary
- Combine archive, thread, post, and lastpost updates into a single forum update
- Restore tab-based indentation for the combined update block

## Testing
- `php -l source/admincp/admincp_counter.php`


------
https://chatgpt.com/codex/tasks/task_e_68b713fda004832eb06e9647367a78f2