### PR TITLE
Fix tag update removal logic

### DIFF
--- a/source/class/class_tag.php
+++ b/source/class/class_tag.php
@@ -60,15 +60,10 @@ class tag
 		foreach($tags as $tagid => $tagname) {
 			$tagstr .= $tagid.','.$tagname."\t";
 		}
-                // Remove obsolete tag links in bulk. The previous implementation
-                // used array_keys on the existing tag list which compared numeric
-                // indexes (0, 1, 2, ...) rather than tag IDs, leaving stale rows in
-                // the association table. Collect tag IDs and issue a single delete
-                // query to reduce database round trips.
-                $tags_to_delete = array_diff($tagidarray, array_keys($tags));
-                if ($tags_to_delete) {
-                        C::t('common_tagitem')->delete_tagitem($tags_to_delete, $itemid, $idtype);
-                }
+		$tags_to_delete = array_diff($tagidarray, array_keys($tags));
+		if ($tags_to_delete) {
+			C::t('common_tagitem')->delete_tagitem($tags_to_delete, $itemid, $idtype);
+		}
 		return $tagstr;
 	}
 

--- a/source/class/class_tag.php
+++ b/source/class/class_tag.php
@@ -60,13 +60,15 @@ class tag
 		foreach($tags as $tagid => $tagname) {
 			$tagstr .= $tagid.','.$tagname."\t";
 		}
-		// Remove obsolete tag links. The previous implementation used
-		// array_keys on the existing tag list which compared numeric indexes
-		// (0, 1, 2, ...) rather than tag IDs, leaving stale rows in the
-		// association table.
-		foreach(array_diff($tagidarray, array_keys($tags)) as $tagid) {
-			C::t('common_tagitem')->delete_tagitem($tagid, $itemid, $idtype);
-		}
+                // Remove obsolete tag links in bulk. The previous implementation
+                // used array_keys on the existing tag list which compared numeric
+                // indexes (0, 1, 2, ...) rather than tag IDs, leaving stale rows in
+                // the association table. Collect tag IDs and issue a single delete
+                // query to reduce database round trips.
+                $tags_to_delete = array_diff($tagidarray, array_keys($tags));
+                if ($tags_to_delete) {
+                        C::t('common_tagitem')->delete_tagitem($tags_to_delete, $itemid, $idtype);
+                }
 		return $tagstr;
 	}
 

--- a/source/class/class_tag.php
+++ b/source/class/class_tag.php
@@ -60,7 +60,11 @@ class tag
 		foreach($tags as $tagid => $tagname) {
 			$tagstr .= $tagid.','.$tagname."\t";
 		}
-		foreach(array_diff(array_keys($tagidarray), array_keys($tags)) as $tagid) {
+		// Remove obsolete tag links. The previous implementation used
+		// array_keys on the existing tag list which compared numeric indexes
+		// (0, 1, 2, ...) rather than tag IDs, leaving stale rows in the
+		// association table.
+		foreach(array_diff($tagidarray, array_keys($tags)) as $tagid) {
 			C::t('common_tagitem')->delete_tagitem($tagid, $itemid, $idtype);
 		}
 		return $tagstr;


### PR DESCRIPTION
## Summary
- ensure tag updates correctly remove obsolete tag associations

## Testing
- `php -l source/class/class_tag.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc447a1fd4832e9be6e1d04c29a906