### PR TITLE
Add cron job to purge old credit logs

### DIFF
--- a/install/data/install_data.sql
+++ b/install/data/install_data.sql
@@ -58,6 +58,7 @@ INSERT INTO pre_common_cron VALUES ('18','0','system','每日用户分表','cron
 INSERT INTO pre_common_cron VALUES ('19','1','system','统计今日热帖','cron_todayheats_daily.php','1269746623','1269792000','-1','-1','0','0');
 INSERT INTO pre_common_cron VALUES ('20','1','system','更新版块最后发表(防水墙相关)','cron_security_cleanup_lastpost.php','1269746623','1269792000','-1','-1','7','0');
 INSERT INTO pre_common_cron VALUES ('21','1','system','每周短信日志归档','cron_smslog_daily.php','1269746639','1269792000','-1','-1','03','0');
+INSERT INTO pre_common_cron VALUES ('22','1','system','积分记录清理','cron_cleancreditlog.php','1269746639','1269792000','-1','-1','0','0');
 
 INSERT INTO pre_common_friendlink VALUES ('1','0','Discuz! 官方论坛','https://www.discuz.vip/','提供最新 Discuz! 产品新闻、软件下载与技术交流','static/image/common/logo_88_31.gif','2');
 INSERT INTO pre_common_friendlink VALUES ('2','4','Discuz! 应用中心','https://addon.dismall.com/','','','2');

--- a/source/admincp/discuzfiles.md5
+++ b/source/admincp/discuzfiles.md5
@@ -831,6 +831,7 @@ f5b9071a79e909400afa730bbc10fd95 *source/include/collection/collection_index.php
 d41d8cd98f00b204e9800998ecf8427e *source/include/collection/index.htm
 d659e4063eaaf2346d348e53f4dc8531 *source/include/cron/cron_announcement_daily.php
 1d1f125af2142c185e5b1257d7b81b6a *source/include/cron/cron_checkpatch_daily.php
+dc6e13ed7ee8b607d75a83718811d16d *source/include/cron/cron_cleancreditlog.php
 25c2dc1dbaf326fdf6b7e6430440e7b5 *source/include/cron/cron_cleanfeed.php
 381f11f42e60b0776ca06a8ade8c75e3 *source/include/cron/cron_cleannotification.php
 e6246d40c1f5c5c0789d9832bb627428 *source/include/cron/cron_cleantrace.php

--- a/source/include/cron/cron_cleancreditlog.php
+++ b/source/include/cron/cron_cleancreditlog.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ *      [Discuz!] (C)2001-2099 Comsenz Inc.
+ *      This is NOT a freeware, use is subject to license terms
+ *
+ *      $Id: cron_cleancreditlog.php 0 2024-04-24 00:00:00Z root $
+ */
+
+if(!defined('IN_DISCUZ')) {
+        exit('Access Denied');
+}
+
+$maxday = 180;
+$deltime = $_G['timestamp'] - $maxday * 86400;
+
+$logids = DB::fetch_all('SELECT logid FROM %t WHERE dateline<%d', array('common_credit_log', $deltime), 'logid');
+if($logids) {
+        DB::delete('common_credit_log', DB::field('logid', array_keys($logids)));
+        DB::delete('common_credit_log_field', DB::field('logid', array_keys($logids)));
+}
+
+DB::query('OPTIMIZE TABLE %t', array('common_credit_log'), true);
+DB::query('OPTIMIZE TABLE %t', array('common_credit_log_field'), true);


### PR DESCRIPTION
## Summary
- add `cron_cleancreditlog.php` to delete credit logs older than 180 days and optimize related tables
- register the cleanup script in default cron schedule and file list

## Testing
- `php -l source/include/cron/cron_cleancreditlog.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcc8b0cb9c832893263de1063480e8