### PR TITLE
Fix indentation in forum thread model

### DIFF
--- a/source/class/model/model_forum_thread.php
+++ b/source/class/model/model_forum_thread.php
@@ -199,10 +199,10 @@ class model_forum_thread extends discuz_model
 			'bbcodeoff' => $this->param['bbcodeoff'],
 			'smileyoff' => $this->param['smileyoff'],
 			'parseurloff' => $this->param['parseurloff'],
-                       'attachment' => '0',
-                       'replycredit' => 0,
-                       'status' => $this->param['pstatus']
-               ));
+			'attachment' => '0',
+			'replycredit' => 0,
+			'status' => $this->param['pstatus']
+		));
 
 		$statarr = array(0 => 'thread', 1 => 'poll', 2 => 'trade', 3 => 'reward', 4 => 'activity', 5 => 'debate', 127 => 'thread');
 		include_once libfile('function/stat');


### PR DESCRIPTION
## Summary
- align insertion array's attachment, replycredit, and status fields with surrounding tab-based indentation

## Testing
- `php -l source/class/model/model_forum_thread.php`


------
https://chatgpt.com/codex/tasks/task_e_68bce7fa66d48328978ca5efae5438ec