### PR TITLE
fix: replace spaces with tabs

### DIFF
--- a/source/include/post/post_editpost.php
+++ b/source/include/post/post_editpost.php
@@ -65,7 +65,7 @@ if($isfirstpost && $isorigauthor && $_G['group']['allowreplycredit']) {
 if(!submitcheck('editsubmit')) {
 
 
-        $postinfo = C::t('forum_post')->fetch_post('tid:'.$_G['tid'], $pid);
+	$postinfo = C::t('forum_post')->fetch_post('tid:'.$_G['tid'], $pid);
 	if($postinfo['fid'] != $_G['fid'] || $postinfo['tid'] != $_G['tid']) {
 		$postinfo = array();
 	}


### PR DESCRIPTION
## Summary
- replace spaces with a tab when fetching post info in post_editpost.php

## Testing
- `php -l source/include/post/post_editpost.php`


------
https://chatgpt.com/codex/tasks/task_e_68bce86b48dc83288cbc4d9c2c7282dd