### PR TITLE
fix: use tabs for htmloncheck indentation

### DIFF
--- a/source/include/post/post_editpost.php
+++ b/source/include/post/post_editpost.php
@@ -74,7 +74,7 @@ if(!submitcheck('editsubmit')) {
 	$urloffcheck = $postinfo['parseurloff'] ? 'checked="checked"' : '';
 	$smileyoffcheck = $postinfo['smileyoff'] == 1 ? 'checked="checked"' : '';
 	$codeoffcheck = $postinfo['bbcodeoff'] == 1 ? 'checked="checked"' : '';
-        $htmloncheck = $postinfo['htmlon'] & 1 ? 'checked="checked"' : '';
+	$htmloncheck = $postinfo['htmlon'] & 1 ? 'checked="checked"' : '';
 
 	if($htmloncheck) {
 		$editor['editormode'] = 0;


### PR DESCRIPTION
## Summary
- ensure `htmloncheck` assignment uses tab indentation in post_editpost

## Testing
- `php -l source/include/post/post_editpost.php`


------
https://chatgpt.com/codex/tasks/task_e_68bce98ddbc08328a7a756aca9faac41