### PR TITLE
Use integer attachment flag

### DIFF
--- a/source/class/model/model_forum_thread.php
+++ b/source/class/model/model_forum_thread.php
@@ -199,7 +199,7 @@ class model_forum_thread extends discuz_model
 			'bbcodeoff' => $this->param['bbcodeoff'],
 			'smileyoff' => $this->param['smileyoff'],
 			'parseurloff' => $this->param['parseurloff'],
-			'attachment' => '0',
+                        'attachment' => 0,
 			'replycredit' => 0,
 			'status' => $this->param['pstatus']
 		));


### PR DESCRIPTION
## Summary
- use an integer 0 when inserting a thread's first post attachment flag for consistency

## Testing
- `php -l source/class/model/model_forum_thread.php`
- `php tests/check_translation_keys.php` *(fails: missing translations)*

------
https://chatgpt.com/codex/tasks/task_e_68bce9dd52c083288a94353a6358b2e1