### PR TITLE
Use tabs for consistent indentation

### DIFF
--- a/source/include/post/post_editpost.php
+++ b/source/include/post/post_editpost.php
@@ -372,17 +372,17 @@ if(!submitcheck('editsubmit')) {
 			$modpost->attach_after_method('editpost', array('class' => 'extend_thread_follow', 'method' => 'after_editpost'));
 		}
 
-               if($_G['group']['allowat']) {
-                       $modpost->attach_before_method('editpost', array('class' => 'extend_thread_allowat', 'method' => 'before_editpost'));
-                       $modpost->attach_after_method('editpost', array('class' => 'extend_thread_allowat', 'method' => 'after_editpost'));
-               }
+		if($_G['group']['allowat']) {
+			$modpost->attach_before_method('editpost', array('class' => 'extend_thread_allowat', 'method' => 'before_editpost'));
+			$modpost->attach_after_method('editpost', array('class' => 'extend_thread_allowat', 'method' => 'after_editpost'));
+		}
 
-               $modpost->attach_before_method('editpost', array('class' => 'extend_thread_image', 'method' => 'before_editpost'));
+		$modpost->attach_before_method('editpost', array('class' => 'extend_thread_image', 'method' => 'before_editpost'));
 
 
-               if($special == '2' && $_G['group']['allowposttrade']) {
-                       $modpost->attach_before_method('editpost', array('class' => 'extend_thread_trade', 'method' => 'before_editpost'));
-               }
+		if($special == '2' && $_G['group']['allowposttrade']) {
+			$modpost->attach_before_method('editpost', array('class' => 'extend_thread_trade', 'method' => 'before_editpost'));
+		}
 
 		$modpost->attach_before_method('editpost', array('class' => 'extend_thread_filter', 'method' => 'before_editpost'));
 		$modpost->attach_after_method('editpost', array('class' => 'extend_thread_filter', 'method' => 'after_editpost'));


### PR DESCRIPTION
## Summary
- replace inconsistent space indentation with tabs in `post_editpost` extension hooks

## Testing
- `php -l source/include/post/post_editpost.php`
- `php tests/check_translation_keys.php` *(fails: missing/unused translations)*
- `php tests/check_discuz_login.php` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_68bcea4c46448328838dffa9df904e94