### PR TITLE
Use integer comparison for post_editpost trade check

### DIFF
--- a/source/include/post/post_editpost.php
+++ b/source/include/post/post_editpost.php
@@ -380,7 +380,7 @@ if(!submitcheck('editsubmit')) {
 		$modpost->attach_before_method('editpost', array('class' => 'extend_thread_image', 'method' => 'before_editpost'));
 
 
-		if($special == '2' && $_G['group']['allowposttrade']) {
+		if($special == 2 && $_G['group']['allowposttrade']) {
 			$modpost->attach_before_method('editpost', array('class' => 'extend_thread_trade', 'method' => 'before_editpost'));
 		}
 


### PR DESCRIPTION
## Summary
- ensure `$special` comparison uses integer for trade posts in `post_editpost.php`

## Testing
- `php -l source/include/post/post_editpost.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcec6971048328867daa239b01234d