### PR TITLE
Optimize related thread fetching

### DIFF
--- a/source/module/forum/forum_viewthread.php
+++ b/source/module/forum/forum_viewthread.php
@@ -1593,10 +1593,10 @@ function getrelateitem($tagarray, $tid, $relatenum, $relatetime, $relatecache = 
 
 
        if(!empty($relatearray)) {
-               foreach($relatearray as $rtid) {
-                       $result = C::t('forum_thread')->fetch($rtid);
-                       if($result && $result['displayorder'] >= 0) {
-                               $relateitem[] = $result;
+               $threads = C::t('forum_thread')->fetch_all_by_tid($relatearray);
+               foreach ($relatearray as $rtid) {
+                       if (isset($threads[$rtid]) && $threads[$rtid]['displayorder'] >= 0) {
+                               $relateitem[] = $threads[$rtid];
                        }
                }
        }


### PR DESCRIPTION
## Summary
- Reduce N+1 queries in related thread fetching by fetching all threads at once

## Testing
- `php -l source/module/forum/forum_viewthread.php`


------
https://chatgpt.com/codex/tasks/task_e_68bced52e7408328a64a827d7219868c