### PR TITLE
Fix indentation in reward thread template

### DIFF
--- a/template/default/forum/viewthread_reward.htm
+++ b/template/default/forum/viewthread_reward.htm
@@ -23,6 +23,7 @@
 		<!--{/if}-->
 	</div>
 <!--{/if}-->
+
 <!--{eval $post['attachment'] = $post['imagelist'] = $post['attachlist'] = '';}-->
 
 <!--{if $bestpost}-->
@@ -32,7 +33,7 @@
 			<div class="psta vm"><a href="home.php?mod=space&uid=$comment[authorid]" c="1">$bestpost[avatar]</a> <a href="home.php?mod=space&uid=$bestpost[authorid]" class="xi2 xw1">$bestpost[author]</a></div>
 			<div class="psti">
 				<p class="xi2"><a href="javascript:;" onclick="window.open('forum.php?mod=redirect&goto=findpost&ptid=$bestpost[tid]&pid=$bestpost[pid]')">{lang view_full_content}</a></p>
-                             <div class="mtn">$bestpost[message]</div>
+				<div class="mtn">$bestpost[message]</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- fix inconsistent indentation in reward template
- use tabs for best answer message

## Testing
- `php -l template/default/forum/viewthread_reward.htm`


------
https://chatgpt.com/codex/tasks/task_e_68bcee27b3a08328ae7b47fc73115acc