### PR TITLE
Fix misaligned template conditionals in viewthread preview

### DIFF
--- a/template/default/forum/viewthread_preview_node.htm
+++ b/template/default/forum/viewthread_preview_node.htm
@@ -2,9 +2,9 @@
 	<!--{if empty($post['deleted'])}-->
 		<!--{if $post[author] && !$post['anonymous']}-->
 		<dd class="m avt"><a href="home.php?mod=space&uid=$post[authorid]"><!--{avatar($post['authorid'], 'small')}--></a></dd>
-						<!--{else}-->
+		<!--{else}-->
 		<dd class="m avt"><img src="{STATICURL}image/magic/hidden.gif" alt="hidden" /></dd>
-					<!--{/if}-->
+		<!--{/if}-->
 		<dt>
 			<span class="y xw0">
 					<!--{if $allowpostreply && $post['invisible'] == 0}-->
@@ -12,11 +12,11 @@
 							<a href="forum.php?mod=post&action=reply&fid=$_G[fid]&tid=$_G[tid]&reppost=$post[pid]&extra=$_GET[extra]&page=$page{if $_GET[from]}&from=$_GET[from]{/if}" onclick="changecontentdivid($_G[tid]);showWindow('reply', this.href)">{lang reply}</a>
 						<!--{else}-->
 							<a href="forum.php?mod=post&action=reply&fid=$_G[fid]&tid=$_G[tid]&repquote=$post[pid]&extra=$_GET[extra]&page=$page{if $_GET[from]}&from=$_GET[from]{/if}" onclick="changecontentdivid($_G[tid]);showWindow('reply', this.href)">{lang reply}</a>
-						<!--{/if}-->
-					<!--{/if}-->
+				<!--{/if}-->
+			<!--{/if}-->
 				<!--{if (($_G['forum']['ismoderator'] && $_G['group']['alloweditpost'] && (!in_array($post['adminid'], array(1, 2, 3)) || $_G['adminid'] <= $post['adminid'])) || ($_G['forum']['alloweditpost'] && $_G['uid'] && ($post['authorid'] == $_G['uid'] && $_G['forum_thread']['closed'] == 0) && !(!$alloweditpost_status && $edittimelimit && TIMESTAMP - $post['dbdateline'] > $edittimelimit)))}-->
 					<a href="forum.php?mod=post&action=edit&fid=$_G[fid]&tid=$_G[tid]&pid=$post[pid]{if !empty($_GET[modthreadkey])}&modthreadkey=$_GET[modthreadkey]{/if}&page=$page{if $_GET[from]}&from=$_GET[from]{/if}"><!--{if $_G['forum_thread']['special'] == 2 && !$post['message']}-->{lang post_add_aboutcounter}<!--{else}-->{lang edit}<!--{/if}--></a>
-					<!--{/if}-->
+			<!--{/if}-->
 
 			</span>
 			<!--{if $post['authorid'] && !$post['anonymous']}-->
@@ -31,15 +31,15 @@
 				{lang guest}
 				<!--{hook/viewthread_postheader $postcount}-->
 				<em id="author_$post[pid]"> {lang poston}</em>
-					<!--{/if}-->
+			<!--{/if}-->
 			<em class="xw0">$post[dateline]</em>
 		</dt>
 		<dd class="z previewPost">
 			<!--{subtemplate forum/viewthread_node_body}-->
 		</dd>
-						<!--{else}-->
+	<!--{else}-->
 		<dd>{lang post_deleted}</dd>
-					<!--{/if}-->
+	<!--{/if}-->
 </dl>
 
 
@@ -50,13 +50,13 @@
 	<!--{if empty($_G['setting']['lazyload'])}-->
 		<!--{if !$post['imagelistthumb']}-->
 			attachimgshow($post[pid]);
-						<!--{else}-->
+		<!--{else}-->
 			attachimgshow($post[pid], 1);
-					<!--{/if}-->
-					<!--{/if}-->
+		<!--{/if}-->
+	<!--{/if}-->
 	<!--{if $post['imagelistthumb']}-->
 		attachimglstshow($post['pid'], <!--{echo intval($_G['setting']['lazyload'])}-->, 0, '{$_G[setting][showexif]}');
-					<!--{/if}-->
+	<!--{/if}-->
 </script>
-					<!--{/if}-->
+<!--{/if}-->
 <!--{hook/viewthread_endline $postcount}-->


### PR DESCRIPTION
## Summary
- Align conditional `if/else` blocks in `viewthread_preview_node` template for clarity
- Normalize indentation in attachment image rendering logic using tabs

## Testing
- `php -l template/default/forum/viewthread_preview_node.htm`


------
https://chatgpt.com/codex/tasks/task_e_68bcf124afcc8328bfea996d03fb0618