### PR TITLE
Load md5 script once

### DIFF
--- a/template/default/touch/forum/viewthread.htm
+++ b/template/default/touch/forum/viewthread.htm
@@ -19,8 +19,9 @@
 		<!--{elseif $_G['forum_thread']['displayorder'] == -4}--> <span>({lang draft})</span>
 		<!--{/if}-->
 	</div>
-	<!--{eval $postcount = 0;}-->
-	<!--{loop $postlist $post}-->
+        <!--{eval $postcount = 0;}-->
+        <!--{eval $needmd5 = 0;}-->
+        <!--{loop $postlist $post}-->
 	<!--{hook/viewthread_posttop_mobile $postcount}-->
 	<div class="plc cl" id="pid$post['pid']">
 		<div class="avatar"><img src="<!--{if !$post['authorid'] || $post['anonymous']}--><!--{avatar(0, 'small', true)}--><!--{else}--><!--{avatar($post['authorid'], 'small', true)}--><!--{/if}-->" /></div>
@@ -190,10 +191,10 @@
 					<div class="quote">{lang message_single_banned}</div>
 				<!--{elseif $post['first'] && $_G['forum_threadpay']}-->
 					<!--{template forum/viewthread_pay}-->
-				<!--{elseif $_G['forum_discuzcode']['passwordlock'][$post['pid']]}-->
-					<script type="text/javascript" src="{$_G['setting']['jspath']}md5.js?{VERHASH}"></script>
-					<div class="locked">{lang message_password_exists} {lang pleaseinputpw}<input type="text" id="postpw_$post[pid]" class="px pl5" /></div>
-					<button class="pn vm" type="button" onclick="submitpostpw($post[pid]{if $_GET['from'] == 'preview'},{$post[tid]}{else}{/if})"><strong>{lang submit}</strong></button>
+                                <!--{elseif $_G['forum_discuzcode']['passwordlock'][$post['pid']]}-->
+                                        <!--{eval $needmd5 = 1;}-->
+                                        <div class="locked">{lang message_password_exists} {lang pleaseinputpw}<input type="text" id="postpw_$post[pid]" class="px pl5" /></div>
+                                        <button class="pn vm" type="button" onclick="submitpostpw($post[pid]{if $_GET['from'] == 'preview'},{$post[tid]}{else}{/if})"><strong>{lang submit}</strong></button>
 				<!--{else}-->
 					<!--{if $_G['setting']['bannedmessages'] & 1 && (($post['authorid'] && !$post['username']) || ($post['groupid'] == 4 || $post['groupid'] == 5))}-->
 						<div class="quote">{lang admin_message_banned}</div>
@@ -428,9 +429,10 @@
 		<div class="view_reply cl"><i class="dm-sofa"></i>{lang mobnoreply}</div>
 		<!--{/if}-->
 	<!--{/if}-->
-	<!--{hook/viewthread_postbottom_mobile $postcount}-->
-	<!--{eval $postcount++;}-->
-	<!--{/loop}-->
+        <!--{hook/viewthread_postbottom_mobile $postcount}-->
+        <!--{eval $postcount++;}-->
+        <!--{/loop}-->
+<!--{if $needmd5}--><script type="text/javascript" src="{$_G['setting']['jspath']}md5.js?{VERHASH}"></script><!--{/if}-->
 </div>
 <script src="kk/zdy3.js?{VERHASH}"></script>
 $multipage


### PR DESCRIPTION
## Summary
- Track when password-protected posts are present and defer md5.js inclusion until after the post loop.
- Ensure md5.js is loaded a single time per page, avoiding redundant script tags.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf4fd91888328b2abdef61da9c27c