### PR TITLE
Load md5 script once

### DIFF
--- a/template/default/touch/forum/viewthread.htm
+++ b/template/default/touch/forum/viewthread.htm
@@ -19,7 +19,7 @@
 		<!--{elseif $_G['forum_thread']['displayorder'] == -4}--> <span>({lang draft})</span>
 		<!--{/if}-->
 	</div>
-	<!--{eval $postcount = 0;}-->
+	<!--{eval $postcount = 0; $needmd5 = 0;}-->
 	<!--{loop $postlist $post}-->
 	<!--{hook/viewthread_posttop_mobile $postcount}-->
 	<div class="plc cl" id="pid$post['pid']">
@@ -191,7 +191,7 @@
 				<!--{elseif $post['first'] && $_G['forum_threadpay']}-->
 					<!--{template forum/viewthread_pay}-->
 				<!--{elseif $_G['forum_discuzcode']['passwordlock'][$post['pid']]}-->
-					<script type="text/javascript" src="{$_G['setting']['jspath']}md5.js?{VERHASH}"></script>
+					<!--{eval $needmd5 = 1;}-->
 					<div class="locked">{lang message_password_exists} {lang pleaseinputpw}<input type="text" id="postpw_$post[pid]" class="px pl5" /></div>
 					<button class="pn vm" type="button" onclick="submitpostpw($post[pid]{if $_GET['from'] == 'preview'},{$post[tid]}{else}{/if})"><strong>{lang submit}</strong></button>
 				<!--{else}-->
@@ -431,6 +431,7 @@
 	<!--{hook/viewthread_postbottom_mobile $postcount}-->
 	<!--{eval $postcount++;}-->
 	<!--{/loop}-->
+	<!--{if $needmd5}--><script type="text/javascript" src="{$_G['setting']['jspath']}md5.js?{VERHASH}"></script><!--{/if}-->
 </div>
 <script src="kk/zdy3.js?{VERHASH}"></script>
 $multipage


### PR DESCRIPTION
## Summary
- Consolidate post counters and md5 flag initialization before iterating posts.
- Track password-locked posts and include md5.js once after the loop.
- Align conditional blocks with tabs for consistent indentation.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf4fd91888328b2abdef61da9c27c