### PR TITLE
Align indentation of reply and edit blocks

### DIFF
--- a/template/default/forum/viewthread_preview_node.htm
+++ b/template/default/forum/viewthread_preview_node.htm
@@ -12,11 +12,11 @@
 							<a href="forum.php?mod=post&action=reply&fid=$_G[fid]&tid=$_G[tid]&reppost=$post[pid]&extra=$_GET[extra]&page=$page{if $_GET[from]}&from=$_GET[from]{/if}" onclick="changecontentdivid($_G[tid]);showWindow('reply', this.href)">{lang reply}</a>
 						<!--{else}-->
 							<a href="forum.php?mod=post&action=reply&fid=$_G[fid]&tid=$_G[tid]&repquote=$post[pid]&extra=$_GET[extra]&page=$page{if $_GET[from]}&from=$_GET[from]{/if}" onclick="changecontentdivid($_G[tid]);showWindow('reply', this.href)">{lang reply}</a>
-				<!--{/if}-->
-			<!--{/if}-->
+						<!--{/if}-->
+					<!--{/if}-->
 				<!--{if (($_G['forum']['ismoderator'] && $_G['group']['alloweditpost'] && (!in_array($post['adminid'], array(1, 2, 3)) || $_G['adminid'] <= $post['adminid'])) || ($_G['forum']['alloweditpost'] && $_G['uid'] && ($post['authorid'] == $_G['uid'] && $_G['forum_thread']['closed'] == 0) && !(!$alloweditpost_status && $edittimelimit && TIMESTAMP - $post['dbdateline'] > $edittimelimit)))}-->
 					<a href="forum.php?mod=post&action=edit&fid=$_G[fid]&tid=$_G[tid]&pid=$post[pid]{if !empty($_GET[modthreadkey])}&modthreadkey=$_GET[modthreadkey]{/if}&page=$page{if $_GET[from]}&from=$_GET[from]{/if}"><!--{if $_G['forum_thread']['special'] == 2 && !$post['message']}-->{lang post_add_aboutcounter}<!--{else}-->{lang edit}<!--{/if}--></a>
-			<!--{/if}-->
+				<!--{/if}-->
 
 			</span>
 			<!--{if $post['authorid'] && !$post['anonymous']}-->


### PR DESCRIPTION
## Summary
- Realign closing `if` markers in thread preview template to match opening conditions with tab-based indentation

## Testing
- `php -l template/default/forum/viewthread_preview_node.htm`


------
https://chatgpt.com/codex/tasks/task_e_68bcf66b00908328b161e0c24e6399aa