### PR TITLE
Fix merged thread dateline

### DIFF
--- a/source/include/topicadmin/topicadmin_merge.php
+++ b/source/include/topicadmin/topicadmin_merge.php
@@ -117,7 +117,7 @@ C::t('forum_thread')->update($_G['tid'], array('tags' => $newtagstr));
 			'authorid' => $firstpost['authorid'],
 			'author' => $firstpost['author'],
 			'subject' => $firstpost['subject'],
-			'dateline' => $firstpost['dateline'],
+			'dateline' => max($thread['dateline'], $other['dateline']),
 			'moderated' => 1,
 			'maxposition' => $other['maxposition'] + $thread['maxposition'],
 		);


### PR DESCRIPTION
## Summary
- Ensure merged threads use the newest creation time between source threads

## Testing
- `php -l source/include/topicadmin/topicadmin_merge.php`


------
https://chatgpt.com/codex/tasks/task_e_68c79cec46308328974a9fd4c26bf42b