### PR TITLE
refactor: remove unused variable in attachimglstshow

### DIFF
--- a/static/js/forum_viewthread.js
+++ b/static/js/forum_viewthread.js
@@ -64,7 +64,6 @@ function attachimgshow(pid, onlyinpost) {
 }
 
 function attachimglstshow(pid, islazy, fid, showexif) {
-        var aimgs = aimgcount[pid];
         var s = '';
         if(fid) {
                 s = ' onmouseover="showMenu({\'ctrlid\':this.id, \'pos\': \'12!\'});"';


### PR DESCRIPTION
## Summary
- tidy forum_viewthread.js by removing an unused `aimgs` variable in `attachimglstshow`
- keep indentation consistent after cleanup

## Testing
- `jshint static/js/forum_viewthread.js` *(fails: 88 errors including ES6 syntax and style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c79d864d108328a7e68d9793b2495a