### PR TITLE
Ensure merged threads keep latest lastpost

### DIFF
--- a/source/include/topicadmin/topicadmin_merge.php
+++ b/source/include/topicadmin/topicadmin_merge.php
@@ -113,6 +113,12 @@ C::t('forum_thread')->update($_G['tid'], array('tags' => $newtagstr));
 			'replies' => $other['replies'],
 		);
 	C::t('forum_thread')->increase($_G['tid'], $fieldarr);
+	$lastpost = $thread['lastpost'];
+	$lastposter = $thread['lastposter'];
+	if($other['lastpost'] > $lastpost) {
+		$lastpost = $other['lastpost'];
+		$lastposter = $other['lastposter'];
+	}
 	$fieldarr = array(
 			'authorid' => $firstpost['authorid'],
 			'author' => $firstpost['author'],
@@ -120,6 +126,8 @@ C::t('forum_thread')->update($_G['tid'], array('tags' => $newtagstr));
 			'dateline' => $firstpost['dateline'],
 			'moderated' => 1,
 			'maxposition' => $other['maxposition'] + $thread['maxposition'],
+			'lastpost' => $lastpost,
+			'lastposter' => $lastposter,
 		);
 	C::t('forum_thread')->update($_G['tid'], $fieldarr);
 	updateforumcount($other['fid']);


### PR DESCRIPTION
## Summary
- ensure thread merges preserve newer `lastpost` and `lastposter`

## Testing
- `php -l source/include/topicadmin/topicadmin_merge.php`
- `php tests/check_translation_keys.php`


------
https://chatgpt.com/codex/tasks/task_e_68c79f14fef48328a2993f21b88eb037