### PR TITLE
Use tabs for merge section indentation

### DIFF
--- a/template/default/forum/topicadmin_action.htm
+++ b/template/default/forum/topicadmin_action.htm
@@ -65,22 +65,22 @@
 				<!--{/if}-->
 			<!--{elseif $_GET[action] == 'merge'}-->
 				<table cellspacing="0" cellpadding="0">
-                                        <tr>
-                                                <td><label for="othertid">{lang admin_merge} &larr;</label></td>
-                                                <td>{lang admin_merge_tid}</td>
-                                        </tr>
-                                        <tr>
-                                                <td>&nbsp;</td>
-                                                <td><input type="text" name="othertid" id="othertid" class="px" size="10" /></td>
-                                        </tr>
-                                        <tr>
-                                                <td><label>{lang admin_merge_order}</label></td>
-                                                <td>
-                                                        <label><input type="radio" name="newpostposition" class="pr" value="0" checked="checked" />{lang admin_merge_order_end}</label>
-                                                        <label><input type="radio" name="newpostposition" class="pr" value="1" />{lang admin_merge_order_begin}</label>
-                                                </td>
-                                        </tr>
-                                </table>
+					<tr>
+						<td><label for="othertid">{lang admin_merge} &larr;</label></td>
+						<td>{lang admin_merge_tid}</td>
+					</tr>
+					<tr>
+						<td>&nbsp;</td>
+						<td><input type="text" name="othertid" id="othertid" class="px" size="10" /></td>
+					</tr>
+					<tr>
+						<td><label>{lang admin_merge_order}</label></td>
+						<td>
+							<label><input type="radio" name="newpostposition" class="pr" value="0" checked="checked" />{lang admin_merge_order_end}</label>
+							<label><input type="radio" name="newpostposition" class="pr" value="1" />{lang admin_merge_order_begin}</label>
+						</td>
+					</tr>
+				</table>
 			<!--{elseif $_GET[action] == 'refund'}-->
 				<table cellspacing="0" cellpadding="0" width="100%">
 					<tr>

--- a/template/default/touch/forum/topicadmin_action.htm
+++ b/template/default/touch/forum/topicadmin_action.htm
@@ -98,30 +98,30 @@
 	<!--{elseif $_GET['action'] == 'merge'}-->
 		<h2 class="log_tit" id="return_merge">{lang admin_merge}</h2>
 		<ul class="post_box cl">
-                        <li class="flex-box mli">
-                                <div class="flex"><span class="z">{lang admin_merge}</span></div>
-                                <div class="flex-2">
-                                        <input type="text" name="othertid" id="othertid" class="px" placeholder="tid" />
-                                </div>
-                        </li>
-                        <label>
-                        <li class="flex-box mli">
-                                <div class="flex">{lang admin_merge_order_end}</div>
-                                <div class="flex-2"></div>
-                                <div class="flex"><span class="y"><input type="radio" name="newpostposition" class="pr" value="0" checked="checked" /></span></div>
-                        </li>
-                        </label>
-                        <label>
-                        <li class="flex-box mli">
-                                <div class="flex">{lang admin_merge_order_begin}</div>
-                                <div class="flex-2"></div>
-                                <div class="flex"><span class="y"><input type="radio" name="newpostposition" class="pr" value="1" /></span></div>
-                        </li>
-                        </label>
-                        <li class="flex-box mli b0">
-                                <div class="flex-3"><span class="z xg1">{lang admin_merge_tid}</span></div>
-                        </li>
-                </ul>
+			<li class="flex-box mli">
+				<div class="flex"><span class="z">{lang admin_merge}</span></div>
+				<div class="flex-2">
+					<input type="text" name="othertid" id="othertid" class="px" placeholder="tid" />
+				</div>
+			</li>
+			<label>
+			<li class="flex-box mli">
+				<div class="flex">{lang admin_merge_order_end}</div>
+				<div class="flex-2"></div>
+				<div class="flex"><span class="y"><input type="radio" name="newpostposition" class="pr" value="0" checked="checked" /></span></div>
+			</li>
+			</label>
+			<label>
+			<li class="flex-box mli">
+				<div class="flex">{lang admin_merge_order_begin}</div>
+				<div class="flex-2"></div>
+				<div class="flex"><span class="y"><input type="radio" name="newpostposition" class="pr" value="1" /></span></div>
+			</li>
+			</label>
+			<li class="flex-box mli b0">
+				<div class="flex-3"><span class="z xg1">{lang admin_merge_tid}</span></div>
+			</li>
+		</ul>
 	<!--{elseif $_GET['action'] == 'refund'}-->
 		<h2 class="log_tit" id="return_refund">{lang modmenu_restore}</h2>
 		<ul class="post_box cl">


### PR DESCRIPTION
## Summary
- normalize indentation in mobile topic admin merge form
- standardize indentation in desktop topic admin merge options

## Testing
- `php -l template/default/forum/topicadmin_action.htm`
- `php -l template/default/touch/forum/topicadmin_action.htm`


------
https://chatgpt.com/codex/tasks/task_e_68c7ba6d00d483288125a970842664a5