### PR TITLE
Remove automatic index.html generation on directory creation

### DIFF
--- a/source/admincp/admincp_db.php
+++ b/source/admincp/admincp_db.php
@@ -292,7 +292,7 @@ if($operation == 'export') {
 						cpmsg('database_export_multivol_succeed', '', 'succeed', array('volume' => $volume, 'filelist' => $filelist, 'deletetips' => $deletetips));
 					}
 					unset($sqldump, $zip, $content);
-					@touch('./data/'.$backupdir.'/index.htm');
+
 					$filename = $zipfilename;
 					C::t('common_cache')->insert(array(
 						'cachekey' => 'db_export',
@@ -302,7 +302,7 @@ if($operation == 'export') {
 					$deletetips = $_G['config']['admincp']['dbimport'] ? cplang('db_delete_tips', array('filename' => basename($zipfilename), 'FORMHASH' => formhash())) : '';
 					cpmsg('database_export_zip_succeed', '', 'succeed', array('filename' => $filename, 'deletetips' => $deletetips));
 				} else {
-					@touch('./data/'.$backupdir.'/index.htm');
+
 					for($i = 1; $i <= $volume; $i++) {
 						$filename = sprintf($_GET['usezip'] == 2 ? $backupfilename."-%s".'.zip' : $dumpfile, $i);
 						$filelist .= "<li><a href=\"$filename\">$filename</a></li>\n";
@@ -360,7 +360,7 @@ if($operation == 'export') {
 						cpmsg('database_export_zip_invalid', '', 'error');
 					}
 					@unlink($dumpfile);
-					@touch('./data/'.$backupdir.'/index.htm');
+
 					$filename = $backupfilename.'.zip';
 					unset($sqldump, $zip, $content);
 					C::t('common_cache')->insert(array(
@@ -376,7 +376,7 @@ if($operation == 'export') {
 						@fwrite($fp, $idstring."# <?php exit();?>\n ".$setnames."\n #");
 						fclose($fp);
 					}
-					@touch('./data/'.$backupdir.'/index.htm');
+
 					$filename = $backupfilename.'.sql';
 					C::t('common_cache')->insert(array(
 						'cachekey' => 'db_export',

--- a/source/class/discuz/discuz_upgrade.php
+++ b/source/class/discuz/discuz_upgrade.php
@@ -197,7 +197,7 @@ class discuz_upgrade {
 			if(!@mkdir($dir, 0777)) {
 				return false;
 			}
-			@touch($dir.'/index.htm'); @chmod($dir.'/index.htm', 0777);
+
 		}
 		return true;
 	}

--- a/source/class/discuz/discuz_upload.php
+++ b/source/class/discuz/discuz_upload.php
@@ -261,7 +261,7 @@ Class discuz_upload{
 		$res = true;
 		if(!is_dir($dir)) {
 			$res = @mkdir($dir, 0777);
-			$index && @touch($dir.'/index.html');
+
 		}
 		return $res;
 	}

--- a/source/function/function_cloudaddons.php
+++ b/source/function/function_cloudaddons.php
@@ -68,8 +68,9 @@ function cloudaddons_check() {
 
 	foreach(array('download', 'addonmd5') as $path) {
 		$tmpdir = DISCUZ_ROOT.'./data/'.$path.'/'.random(5);
-		$tmpfile = $tmpdir.'/index.html';
+		$tmpfile = $tmpdir.'/test.txt';
 		dmkdir($tmpdir, 0777);
+		@touch($tmpfile);
 		if(!is_dir($tmpdir) || !file_exists($tmpfile)) {
 			cpmsg('cloudaddons_check_write_error', '', 'error');
 		}

--- a/source/function/function_core.php
+++ b/source/function/function_core.php
@@ -1736,9 +1736,6 @@ function dmkdir($dir, $mode = 0777, $makeindex = TRUE){
 	if(!is_dir($dir)) {
 		dmkdir(dirname($dir), $mode, $makeindex);
 		@mkdir($dir, $mode);
-		if(!empty($makeindex)) {
-			@touch($dir.'/index.html'); @chmod($dir.'/index.html', 0777);
-		}
 	}
 	return true;
 }

--- a/source/include/cron/cron_cleanup_daily.php
+++ b/source/include/cron/cron_cleanup_daily.php
@@ -39,10 +39,10 @@ C::t('forum_tradelog')->expiration_finished(7);
 
 if($_G['setting']['cachethreadon']) {
 	removedir($_G['setting']['cachethreaddir'], TRUE);
-	touch($_G['setting']['cachethreaddir'].'/index.htm');
+
 }
 removedir($_G['setting']['attachdir'].'image', TRUE);
-@touch($_G['setting']['attachdir'].'image/index.htm');
+
 
 C::t('forum_attachment_unused')->clear();
 


### PR DESCRIPTION
This commit fulfills the user request to stop Discuz from automatically generating blank `index.html` or `index.htm` files when creating new directories (e.g., attachment folders). 

We scrubbed this behavior out of:
- `source/function/function_core.php` (`dmkdir` function)
- `source/class/discuz/discuz_upload.php` (`make_dir` function)
- `source/class/discuz/discuz_upgrade.php` (`mkdirs` function)
- `source/include/cron/cron_cleanup_daily.php` (daily cleanup routines)
- `source/admincp/admincp_db.php` (database backups)

Function signatures (like `$makeindex`) were left intact to avoid breaking plugins or other components that pass those arguments.

---
*PR created automatically by Jules for task [11014562930973942127](https://jules.google.com/task/11014562930973942127) started by @hbghlyj*