### PR TITLE
chore: bump MathJax version to always use the latest v4

### DIFF
--- a/kk/mathjax.php
+++ b/kk/mathjax.php
@@ -50,4 +50,4 @@
     }
   }
 </script>
-<script src="https://unpkg.com/mathjax@4.1.0/tex-chtml.js" async></script>
+<script src="https://unpkg.com/mathjax@4/tex-chtml.js" async></script>


### PR DESCRIPTION
Update MathJax script URL to `https://unpkg.com/mathjax@4/tex-chtml.js` in `kk/mathjax.php` to ensure the latest MathJax 4.x version is always used.

---
*PR created automatically by Jules for task [5595078309510063931](https://jules.google.com/task/5595078309510063931) started by @hbghlyj*