### PR TITLE
Remove email and mobile number obfuscation from account settings

### DIFF
--- a/template/default/home/spacecp_account.php
+++ b/template/default/home/spacecp_account.php
@@ -75,8 +75,7 @@
                     <th>{lang action_account_security_type_email}</th>
                     <td>
                         <!--{if $_G['member']['email']}-->
-                            <!--{eval $email_arr = explode('@', $_G['member']['email']);}-->
-                            <!--{eval echo substr($email_arr[0], 0, 3).'****' . '@' . $email_arr[1]}-->
+                            {$_G['member']['email']}
                             <!--{if $_G['member']['emailstatus']}-->
                                 <span style="color: green;">({lang action_account_status_active})</span>
                             <!--{else}-->
@@ -101,7 +100,7 @@
                     <td>
                         <!--{if $_G['member']['secmobile']}-->
                         <!--{if $_G['member']['secmobicc']}-->+{$_G['member']['secmobicc']} <!--{/if}-->
-                        <!--{eval echo substr($_G['member']['secmobile'], 0, 3).'****'.substr($_G['member']['secmobile'], -3);}-->
+                        {$_G['member']['secmobile']}
                         <!--{else}-->
                         {lang action_account_security_type_data_empty}
                         <!--{/if}-->

--- a/template/default/home/spacecp_account_security_verify.php
+++ b/template/default/home/spacecp_account_security_verify.php
@@ -34,7 +34,7 @@
                                 <input type="hidden" id="idstring_v" name="idstring_v" value="{$idstring_v}" />
                                 <input type="hidden" id="sign_v" name="sign_v" value="{$sign_v}" />
                             <!--{else}-->
-                            +{$_G['member']['secmobicc']} <!--{eval echo substr($_G['member']['secmobile'], 0, 3).'****'.substr($_G['member']['secmobile'], -3);}-->
+                            +{$_G['member']['secmobicc']} {$_G['member']['secmobile']}
                             <input type="hidden" id="secmobicc" name="secmobicc" value="{$_G['member']['secmobicc']}" />
                             <input type="hidden" id="secmobile" name="secmobile" value="{$_G['member']['secmobile']}" />
                             <!--{/if}-->

--- a/template/default/home/spacecp_account_security_verify_email.php
+++ b/template/default/home/spacecp_account_security_verify_email.php
@@ -21,8 +21,7 @@
                             <!--{if $method == 'chgemail' && empty($_G['member']['email'])}-->
                                 <input type="text" name="email" id="email" class="px"/>
                             <!--{else}-->
-                            <!--{eval $email_arr = explode('@', $_G['member']['email']);}-->
-                            <!--{eval echo substr($email_arr[0], 0, 3).'****' . '@' . $email_arr[1]}-->
+                            {$_G['member']['email']}
                             <input type="hidden" id="email" name="email" value="{$_G['member']['email']}" />
                             <!--{/if}-->
                         </td>

--- a/template/default/touch/home/spacecp_account.php
+++ b/template/default/touch/home/spacecp_account.php
@@ -78,8 +78,7 @@
                             <a href="home.php?mod=spacecp&ac=account&op=verify&method=chgemail&formhash={FORMHASH}" style="color: green;" class="dialog">{lang action_account_operate_chg}</a>
                         </p>
                         <!--{if $_G['member']['email']}-->
-                            <!--{eval $email_arr = explode('@', $_G['member']['email']);}-->
-                            <!--{eval echo substr($email_arr[0], 0, 3).'****' . '@' . $email_arr[1]}-->
+                            {$_G['member']['email']}
                             <!--{if $_G['member']['emailstatus']}-->
                                 <span style="color: green;">({lang action_account_status_active})</span>
                             <!--{else}-->
@@ -109,7 +108,7 @@
                         </p>
                         <!--{if $_G['member']['secmobile']}-->
                         <!--{if $_G['member']['secmobicc']}-->+{$_G['member']['secmobicc']} <!--{/if}-->
-                        <!--{eval echo substr($_G['member']['secmobile'], 0, 3).'****'.substr($_G['member']['secmobile'], -3);}-->
+                        {$_G['member']['secmobile']}
                         <!--{else}-->
                         {lang action_account_security_type_data_empty}
                         <!--{/if}-->

--- a/template/default/touch/home/spacecp_account_security_verify.php
+++ b/template/default/touch/home/spacecp_account_security_verify.php
@@ -27,7 +27,7 @@
                     <input type="hidden" id="idstring_v" name="idstring_v" value="{$idstring_v}" />
                     <input type="hidden" id="sign_v" name="sign_v" value="{$sign_v}" />
                     <!--{else}-->
-                    {lang secmobile}: +{$_G['member']['secmobicc']} <!--{eval echo substr($_G['member']['secmobile'], 0, 3).'****'.substr($_G['member']['secmobile'], -3);}-->
+                    {lang secmobile}: +{$_G['member']['secmobicc']} {$_G['member']['secmobile']}
                     <input type="hidden" id="secmobicc" name="secmobicc" value="{$_G['member']['secmobicc']}" />
                     <input type="hidden" id="secmobile" name="secmobile" value="{$_G['member']['secmobile']}" />
                     <!--{/if}-->

--- a/template/default/touch/home/spacecp_account_security_verify_email.php
+++ b/template/default/touch/home/spacecp_account_security_verify_email.php
@@ -14,8 +14,7 @@
                     <!--{if $method == 'chgemail' && empty($_G['member']['email'])}-->
                     <input type="text" name="email" id="secemail" class="px" placeholder="{lang email}"/>
                     <!--{else}-->
-                    <!--{eval $email_arr = explode('@', $_G['member']['email']);}-->
-                    <!--{eval echo substr($email_arr[0], 0, 3).'****' . '@' . $email_arr[1]}-->
+                    {$_G['member']['email']}
                     <input type="hidden" id="secemail" name="email" value="{$_G['member']['email']}" />
                     <!--{/if}-->
                 </td>


### PR DESCRIPTION
Removes asterisk masking from the user's email address and security mobile phone number on the account settings and security verification pages across both desktop and mobile layouts. This ensures the full information is visible to the authenticated user for easier verification or modification.

---
*PR created automatically by Jules for task [6291742429118374673](https://jules.google.com/task/6291742429118374673) started by @hbghlyj*