### PR TITLE
fix(admincp): correct search index metadata for accountguard settings

### DIFF
--- a/source/app/admin/child/setting/accountguard.php
+++ b/source/app/admin/child/setting/accountguard.php
@@ -32,7 +32,7 @@ if(submitcheck('settingsubmit')) {
 	loadcache('usergroups');
 	$setting['accountguard'] = dunserialize($setting['accountguard']);
 	$usergroups = table_common_usergroup_field::t()->fetch_all(array_keys($_G['cache']['usergroups']));
-	/*search={"setting_accountguard":"action=setting&operation=sec","setting_sec_reginput":"action=setting&operation=sec&anchor=accountguard"}*/
+	/*search={"setting_accountguard":"action=setting&operation=accountguard"}*/
 	showtableheader('', 'nobottom');
 	$forcelogin = '<tr class="header"><td></td><td>'.cplang('usergroups_edit_basic_forcelogin_none').'</td><td>'.cplang('usergroups_edit_basic_forcelogin_mail').'</td></tr>';
 	ksort($_G['cache']['usergroups']);


### PR DESCRIPTION
Fix AdminCP search redirects for accountguard settings by updating the search JSON metadata in `accountguard.php`.

---
*PR created automatically by Jules for task [9901229233749673801](https://jules.google.com/task/9901229233749673801) started by @hbghlyj*