### PR TITLE
🛡️ Sentinel: [HIGH] Fix PHP Insecure Deserialization in core dunserialize

### DIFF
--- a/source/function/function_core.php
+++ b/source/function/function_core.php
@@ -2892,11 +2892,12 @@ function strhash($string, $operation = 'DECODE', $key = '') {
 
 function dunserialize($data) {
 	// 由于 Redis 驱动侧以序列化保存 array, 取出数据时会自动反序列化（导致反序列化了非Redis驱动序列化的数据），因此存在参数入参为 array 的情况.
-	// 考虑到 PHP 8 增强了类型体系, 此类数据直接送 unserialize 会导致 Fatal Error, 需要通过代码层面对此情况进行规避.
+	// 考虑到 PHP 8 增强了类型体系, 此类数据直接送 unserialize 会导致 Fatal Error, 需要通过代码层层面进行规避.
+	// 同时使用 allowed_classes => false 限制反序列化时实例化对象，防止 PHP 对象注入 (PHP Object Injection) 漏洞.
 	if(is_array($data)) {
 		$ret = $data;
-	} elseif(($ret = @unserialize($data)) === false) {
-		$ret = @unserialize(stripslashes($data));
+	} elseif(($ret = @unserialize($data, ['allowed_classes' => false])) === false) {
+		$ret = @unserialize(stripslashes($data), ['allowed_classes' => false]);
 	}
 	return $ret;
 }


### PR DESCRIPTION
Add ['allowed_classes' => false] option to native unserialize() calls inside the core dunserialize() function in source/function/function_core.php. This disables class instantiation during deserialization across the application, mitigating PHP Object Injection (Insecure Deserialization) vulnerabilities.

---
*PR created automatically by Jules for task [1378683995674289355](https://jules.google.com/task/1378683995674289355) started by @hbghlyj*