### PR TITLE
fix: update Node.js version and fix SQL import syntax error in Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Dependencies
         run: npm install playwright
@@ -37,7 +37,7 @@ jobs:
           sudo mysql -u root -e "GRANT ALL PRIVILEGES ON ultrax.* TO 'discuz'@'127.0.0.1';"
           sudo mysql -u root -e "FLUSH PRIVILEGES;"
 
-          sudo mysql -u root ultrax < install/sql/sql_install.php
+          sed '1d' install/sql/sql_install.php | sudo mysql -u root ultrax
 
           cp config/config_global_default.php config/config_global.php
           sed -i "s/\$_config\['db'\]\[1\]\['dbname'\]  		= 'mitframe';/\$_config['db'][1]['dbname'] = 'ultrax';/g" config/config_global.php

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,7 +45,7 @@ jobs:
           sed -i "s/\$_config\['db'\]\[1\]\['dbpw'\] 	 	= '';/\$_config['db'][1]['dbpw'] = 'password';/g" config/config_global.php
           sed -i "s/\$_config\['db'\]\[1\]\['dbhost'\]  		= 'localhost';/\$_config['db'][1]['dbhost'] = '127.0.0.1';/g" config/config_global.php
 
-          mkdir -m 777 -p data/template/EN data/template/TC data/sysdata json temp
+          mkdir -m 777 -p data/template/EN data/template/TC data/sysdata data/cache json temp
           chmod 777 data/cache temp
 
           mkdir -p chat/php/vendor


### PR DESCRIPTION
This pull request resolves a failing GitHub Actions workflow (`playwright.yml`). It fixes two issues:
1.  **Node.js Deprecation:** The workflow was forcing Node.js 20 on a runner that expected Node.js 24. This has been updated to use `node-version: '24'`.
2.  **SQL Import Error:** The `Configure Database & DiscuzX` step was failing because `install/sql/sql_install.php` begins with a PHP security tag (`<?php exit('Access Denied');?>`), which causes a syntax error when piped directly into the `mysql` CLI tool. This has been fixed by using `sed '1d'` to strip the first line prior to the import.

---
*PR created automatically by Jules for task [17709982567204178623](https://jules.google.com/task/17709982567204178623) started by @hbghlyj*