### PR TITLE
ci: fail workflow on PHP server 4xx/5xx errors

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -61,6 +61,16 @@ jobs:
           node tools/test_forum.js
           node tools/test_tags.js
 
+      - name: Check PHP Server Errors
+        if: always()
+        run: |
+          if grep -E '\[(4|5)[0-9]{2}\]:' php_server.log; then
+            echo "Found HTTP 4xx or 5xx errors in php_server.log"
+            exit 1
+          else
+            echo "No HTTP 4xx or 5xx errors found."
+          fi
+
       - name: Upload Screenshots and Report
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Update github workflow to treat 4xx and 5xx status codes in php_server.log as errors

This adds a post-test step in the Playwright GitHub Actions workflow
that scans the php_server.log output using grep. If any HTTP 4xx or 5xx
status codes are found (indicating backend errors during test runs), the
workflow step will fail (exit 1), ensuring that backend regressions
don't slip by silently even if the frontend tests happen to pass.

---
*PR created automatically by Jules for task [14441474407242458958](https://jules.google.com/task/14441474407242458958) started by @hbghlyj*