### PR TITLE
Update test tools to fail on browser console errors

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -61,6 +61,16 @@ jobs:
           node tools/test_forum.js
           node tools/test_tags.js
 
+      - name: Check PHP Server Errors
+        if: always()
+        run: |
+          if grep -E '\[(4|5)[0-9]{2}\]:' php_server.log; then
+            echo "Found HTTP 4xx or 5xx errors in php_server.log"
+            exit 1
+          else
+            echo "No HTTP 4xx or 5xx errors found."
+          fi
+
       - name: Upload Screenshots and Report
         uses: actions/upload-artifact@v4
         if: always()

--- a/tools/test_forum.js
+++ b/tools/test_forum.js
@@ -8,6 +8,16 @@ const { execSync } = require('child_process');
     const context = await browser.newContext();
     const page = await context.newPage();
 
+    page.on('pageerror', exception => {
+        throw new Error(`Uncaught exception in browser: ${exception}`);
+    });
+
+    page.on('console', msg => {
+        if (msg.type() === 'error') {
+            throw new Error(`Console error in browser: ${msg.text()}`);
+        }
+    });
+
     let report = "# DiscuzX Functional Test Report\n\n";
     console.log("Starting functional tests...");
 

--- a/tools/test_tags.js
+++ b/tools/test_tags.js
@@ -8,6 +8,16 @@ const { execSync } = require('child_process');
     const context = await browser.newContext();
     const page = await context.newPage();
 
+    page.on('pageerror', exception => {
+        throw new Error(`Uncaught exception in browser: ${exception}`);
+    });
+
+    page.on('console', msg => {
+        if (msg.type() === 'error') {
+            throw new Error(`Console error in browser: ${msg.text()}`);
+        }
+    });
+
     let report = "\n\n## Tags Feature Functional Test Report\n\n";
     console.log("Starting Tags Feature tests...");
 


### PR DESCRIPTION
This extends the previous update by explicitly adding listeners for the `pageerror` and `console` (error) events in the Playwright test runners (`test_forum.js` and `test_tags.js`). If an uncaught exception or console error is fired from the browser context during testing, the Node runner will throw an exception and crash, which will subsequently fail the GitHub Action step.