### PR TITLE
Fix Playwright tests by preventing common_syscache truncation and rebuilding caches

### DIFF
--- a/tools/test_forum.js
+++ b/tools/test_forum.js
@@ -40,10 +40,13 @@ const { execSync } = require('child_process');
         C::t('common_setting')->update('secqaa', serialize(\$secqaa));
         C::t('common_setting')->update('regname', 'register');
 
-        DB::query('TRUNCATE TABLE '.DB::table('common_syscache'));
+        if(!is_dir('./data/cache')) {
+            @mkdir('./data/cache', 0777, true);
+        }
+        @chmod('./data/cache', 0777);
+
         require_once libfile('function/cache');
-        updatecache('setting');
-        updatecache('secqaa');
+        updatecache();
         ?>`;
         fs.writeFileSync('disable_sec.php', phpConfig);
         execSync('php disable_sec.php');


### PR DESCRIPTION
This change fixes the HTTP 404 errors during Playwright functional tests on CI. Previously, `tools/test_forum.js` cleared the `common_syscache` table and only updated setting/secqaa caches, leaving style_default and other critical caches empty. This caused empty STYLEID and path variables, resulting in requests to invalid paths like `/_common.css` and `/common.js`. By ensuring `data/cache` is properly created and invoking a full `updatecache()`, we guarantee style/setting/general caches are correctly rebuilt, preventing the 404 errors.

---
*PR created automatically by Jules for task [4437690164414440766](https://jules.google.com/task/4437690164414440766) started by @hbghlyj*