### PR TITLE
PM view & thread/search fixes; add DB seeding in Playwright CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -83,6 +83,9 @@ jobs:
           cp chat/php/config_default.php chat/php/config.php
           echo '<?php if (!class_exists("Pusher")) {     class Pusher {         public function __construct(...$args) {}         public function trigger($channel, $event, $data, $a = null, $b = null)         {             return true;         }     } } ?>'  > source/class/class_pusher.php
           DISCUZ_SEED_DATABASE=1 php tools/import_all_data.php
+
+          mysql ultrax -e "REPLACE INTO pre_common_setting SET skey='homestatus', svalue='1';"
+          php -r 'require "./source/class/class_core.php"; $discuz = C::app(); $discuz->init(); require_once libfile("function/cache"); updatecache("setting");'
       - name: Start PHP Server
         run: php -S 127.0.0.1:8080 > php_server.log 2>&1 &
 

--- a/source/app/home/child/space/pm.php
+++ b/source/app/home/child/space/pm.php
@@ -112,14 +112,13 @@ if($_GET['subop'] == 'view') {
 
 } elseif($_GET['subop'] == 'viewg') {
 
-	$grouppm = table_common_grouppm::t()->fetch($_GET['pmid']);
-	if(!$grouppm) {
-		$grouppm = array_merge((array)table_common_member_grouppm::t()->fetch_gpm($_G['uid'], $_GET['pmid']), $grouppm);
-	}
+	$gpmuser = table_common_member_grouppm::t()->fetch_gpm($_G['uid'], $_GET['pmid']);
+	$grouppm = $gpmuser ? table_common_grouppm::t()->fetch($_GET['pmid']) : [];
 	if($grouppm) {
+		$grouppm = array_merge($grouppm, $gpmuser);
 		$grouppm['numbers'] = $grouppm['numbers'] - 1;
 	}
-	if(!$grouppm['status']) {
+	if($grouppm && !$grouppm['status']) {
 		table_common_member_grouppm::t()->update($_G['uid'], $_GET['pmid'], ['status' => 1, 'dateline' => TIMESTAMP]);
 	}
 	$actives['announcepm'] = ' class="a"';

--- a/source/app/home/child/space/thread.php
+++ b/source/app/home/child/space/thread.php
@@ -20,7 +20,7 @@ if($page < 1) $page = 1;
 $id = empty($_GET['id']) ? 0 : intval($_GET['id']);
 $opactives['thread'] = 'class="a"';
 
-$_GET['view'] = in_array($_GET['view'], ['we', 'me', 'all']) ? $_GET['view'] : 'we';
+$_GET['view'] = in_array($_GET['view'], ['we', 'me', 'all']) ? $_GET['view'] : 'me';
 $_GET['order'] = in_array(getgpc('order'), ['hot', 'dateline']) ? $_GET['order'] : 'dateline';
 
 $allowviewuserthread = $_G['setting']['allowviewuserthread'];

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -5,14 +5,15 @@
  */
 
 function normalizeI18nKey(key) {
-	switch (key) {
-		case 'en':
-			return 'EN_UTF8';
-		case 'tc':
-			return 'TC_UTF8';
-		default:
-			return 'SC_UTF8';
+	if (!key) return 'SC_UTF8';
+	key = key.toLowerCase();
+	if (key === 'en' || key === 'en_utf8') {
+		return 'EN_UTF8';
 	}
+	if (key === 'tc' || key === 'tc_utf8') {
+		return 'TC_UTF8';
+	}
+	return 'SC_UTF8';
 }
 
 var _i18n_ = normalizeI18nKey(typeof DISCUZ_I18N != 'undefined' ? DISCUZ_I18N : '');

--- a/template/default/search/forum.htm
+++ b/template/default/search/forum.htm
@@ -1,6 +1,7 @@
 <!--{template search/header}-->
 <div id="ct" class="cl w">
 	<div class="mw">
+		<!--{if empty($searchid)}-->
 		<form class="searchform" method="post" autocomplete="off" action="search.php?mod=forum" onsubmit="if($('scform_srchtxt')) searchFocus($('scform_srchtxt'));">
 			<input type="hidden" name="formhash" value="{FORMHASH}" />
 			<!--{subtemplate search/pubsearch}-->
@@ -103,8 +104,10 @@
 			</div>
 		</div>
 
+		<!--{else}-->
 		<!--{if !empty($searchid) && submitcheck('searchsubmit', 1)}-->
 			<!--{subtemplate search/thread_list}-->
+		<!--{/if}-->
 		<!--{/if}-->
 	</div>
 </div>

--- a/template/default/touch/common/common.css
+++ b/template/default/touch/common/common.css
@@ -368,6 +368,9 @@ select {-moz-appearance:none;}
 .header .myss a i {float:left;font-size:16px;margin-right:5px;color:rgba(255,255,255,0.7)}
 .header i {font-size:20px;color:var(--dz-FC-fff)}
 .header .my a {margin-left:10px}
+.header .pm_send {width:30%}
+.header .pm_send a {color:var(--dz-FC-fff);font-size:14px;white-space:nowrap}
+.header.pm_header h2 {width:50%}
 .header h2 {float:left;width:60%;text-align:center;font-size:18px;position:relative;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}
 .header h2 img, .header .mzlogo img {max-height:30px;vertical-align:top;max-width:100%}
 .header h2 a {color:var(--dz-FC-fff)}

--- a/template/default/touch/home/space_pm.htm
+++ b/template/default/touch/home/space_pm.htm
@@ -2,10 +2,10 @@
 <!--{template common/header}-->
 <!--{if in_array($filter, array('privatepm')) || in_array($_GET['subop'], array('view'))}-->
 	<!--{if in_array($filter, array('privatepm'))}-->
-	<div class="header cl">
+	<div class="header pm_header cl">
 		<div class="mz"><a href="javascript:history.back();"><i class="dm-c-left"></i></a></div>
 		<h2>{lang mypm}</h2>
-		<div class="my"><a href="home.php?mod=spacecp&ac=pm"><i class="dm-edit"></i></a></div>
+		<div class="my pm_send"><a href="home.php?mod=spacecp&ac=pm">{lang send_pm}</a></div>
 	</div>
 	<div class="dhnv flex-box cl">
 		<a href="home.php?mod=space&do=pm" class="flex mon">{lang mypm}<!--{if $newpmcount}--><strong>($newpmcount)</strong><!--{/if}--></a>

--- a/template/discuzx5/common/extend_common.css
+++ b/template/discuzx5/common/extend_common.css
@@ -302,7 +302,7 @@ form[action*="ac=privacy&op="] .tfm caption h2.ptw {padding-top:0px !important}
 .dz_tbnvb .tb a {background:none;font-size:15px;border:none;padding:0}
 .dz_tbnvb .tb .a:after, .dz_tbnvb .tb .current:after {content:"";position:relative;bottom:-18px;display:flex;margin:0 auto;width:100%;height:2px;background:var(--dz-color);border-radius:var(--dz-radius-x)}
 .dz_tbnvb .tb .o {margin-right:0;margin-left:10px;font-size:12px !important}
-.dz_tbnvb .tb .o a {padding:0 10px;background:var(--dz-btnbga);font-size:12px !important;color:var(--dz-btntxt)}
+.dz_tbnvb .tb .o a {padding:0 10px;background:var(--dz-btnbga);font-size:12px !important;color:var(--dz-btntxta)}
 .dz_tbnvb .tb .kmfa_rss {margin-top:0;padding-left:20px !important;background-position:0 3px !important}
 .dz_tbnvb .tb .y {margin-right:0}
 .dz_tbnvb .tb .y:after {display:none}

--- a/tools/test_forum.js
+++ b/tools/test_forum.js
@@ -80,6 +80,28 @@ const { execSync } = require('child_process');
         assert.strictEqual(await textEditor.count(), 1, 'Assertion Error: Visible post editor did not render.');
         await textEditor.fill(message);
     };
+    const sendPrivateMessage = async (senderPage, recipient, message) => {
+        await senderPage.goto('http://127.0.0.1:8080/home.php?mod=spacecp&ac=pm');
+        await senderPage.waitForLoadState('networkidle');
+        const pmForm = senderPage.locator('form[id^="pmform_"]:visible');
+        assert.strictEqual(await pmForm.count(), 1, 'Assertion Error: PM compose form did not render.');
+        const recipientInput = pmForm.locator('input[name="username"]');
+        const messageInput = pmForm.locator('textarea[name="message"]');
+        const submitButton = pmForm.locator('#pmsubmit_btn');
+        assert.strictEqual(await recipientInput.count(), 1, 'Assertion Error: PM recipient field did not render.');
+        assert.strictEqual(await messageInput.count(), 1, 'Assertion Error: PM message field did not render.');
+        assert.strictEqual(await submitButton.count(), 1, 'Assertion Error: PM submit button did not render.');
+        await recipientInput.fill(recipient);
+        await messageInput.fill(message);
+        const responsePromise = senderPage.waitForResponse(response =>
+            response.request().method() === 'POST' &&
+            response.url().includes('home.php?mod=spacecp&ac=pm&op=send')
+        );
+        await submitButton.click();
+        const response = await responsePromise;
+        const responseText = await response.text();
+        assert.ok(response.ok(), `Assertion Error: PM send request failed: status=${response.status()}; body=${responseText.slice(0, 2000)}`);
+    };
     console.log("Starting functional tests...");
 
     try {
@@ -377,21 +399,10 @@ const { execSync } = require('child_process');
         report += '### 4b. Personal Info Update & Space Threads Verification\n- **Status**: Checked\n- **spacecp Update**: Success\n- **Threads Page (with view=me)**: Success — `screenshot_space_thread_viewme.png`\n- **Threads Page (without view=me)**: Success — `screenshot_space_thread_default.png`\n\n';
 
         console.log("Testing Personal Messages (PM) on Desktop via UI...");
-        await page.goto('http://127.0.0.1:8080/home.php?mod=spacecp&ac=pm');
-        await page.waitForLoadState('networkidle');
-        const sendPmUsernameInput = await page.$('input[name="username"], input[name="touid"], #username');
-        if (sendPmUsernameInput) {
-            await sendPmUsernameInput.fill('admin');
-            const pmMessageInput = await page.$('textarea[name="message"], #pmmessage, #replymessage');
-            if (pmMessageInput) {
-                await pmMessageInput.fill('UI sent test message to admin');
-                const sendPmBtn = await page.$('#pmsubmit_btn, button[name="pmsubmit"], button[type="submit"]');
-                if (sendPmBtn) {
-                    await sendPmBtn.click();
-                    await page.waitForTimeout(1000);
-                }
-            }
-        }
+        const userPmToAdmin = 'UI sent test message to admin.';
+        await sendPrivateMessage(page, 'admin', userPmToAdmin);
+        const userPmDbCheck = execSync(`sudo mysql -u root ultrax -N -s -e "SELECT COUNT(*) FROM pre_common_pm_message p INNER JOIN pre_common_pm_member m ON m.plid=p.plid WHERE m.uid='1' AND p.authorid='${userUid}' AND p.message='${userPmToAdmin}';"`).toString().trim();
+        assert.strictEqual(userPmDbCheck, '1', 'Assertion Error: User PM was not delivered to the admin inbox.');
 
         console.log("Testing Reply Quote & Notification (do=notice) and PM send back from admin via UI...");
         if (tidOutput) {
@@ -411,22 +422,10 @@ const { execSync } = require('child_process');
                 adminLoginForm.evaluate(form => form.submit())
             ]);
 
-            // Admin sends PM back to user
-            await adminPage.goto('http://127.0.0.1:8080/home.php?mod=spacecp&ac=pm');
-            await adminPage.waitForLoadState('networkidle');
-            const adminSendPmUserInput = await adminPage.$('input[name="username"], input[name="touid"], #username');
-            if (adminSendPmUserInput) {
-                await adminSendPmUserInput.fill(username);
-                const adminPmMessageInput = await adminPage.$('textarea[name="message"], #pmmessage, #replymessage');
-                if (adminPmMessageInput) {
-                    await adminPmMessageInput.fill('Admin reply PM to user via UI.');
-                    const adminSendPmBtn = await adminPage.$('#pmsubmit_btn, button[name="pmsubmit"], button[type="submit"]');
-                    if (adminSendPmBtn) {
-                        await adminSendPmBtn.click();
-                        await adminPage.waitForTimeout(1000);
-                    }
-                }
-            }
+            const adminPmToUser = 'Admin reply PM to user via UI.';
+            await sendPrivateMessage(adminPage, username, adminPmToUser);
+            const adminPmDbCheck = execSync(`sudo mysql -u root ultrax -N -s -e "SELECT COUNT(*) FROM pre_common_pm_message p INNER JOIN pre_common_pm_member m ON m.plid=p.plid WHERE m.uid='${userUid}' AND p.authorid='1' AND p.message='${adminPmToUser}';"`).toString().trim();
+            assert.strictEqual(adminPmDbCheck, '1', 'Assertion Error: Admin PM was not delivered to the user inbox.');
 
             await adminPage.goto(`http://127.0.0.1:8080/forum.php?mod=post&action=reply&fid=2&tid=${tidOutput}&reppost=${firstPid}`);
             await adminPage.waitForLoadState('networkidle');
@@ -450,7 +449,7 @@ const { execSync } = require('child_process');
             await page.waitForLoadState('networkidle');
             await page.screenshot({ path: 'screenshot_desktop_pm.png' });
             const pmBody = await page.textContent('body');
-            assert.ok(pmBody.includes('PM') || pmBody.includes('Message') || pmBody.includes('admin') || pmBody.includes(username), 'Assertion Error: Desktop PM center did not load correctly.');
+            assert.ok(pmBody.includes(adminPmToUser), 'Assertion Error: Desktop PM center did not display the delivered admin message.');
             report += '### 4c. Desktop Personal Message (PM)\n- **Status**: Checked\n- **Send PM via UI**: Success\n- **Admin Send Back PM**: Success\n- **PM Center View**: Success\n- **Screenshot**: `screenshot_desktop_pm.png`\n\n';
 
             const adminReplyDbCheck = execSync(`sudo mysql -u root ultrax -N -s -e "SELECT COUNT(*) FROM pre_forum_post WHERE tid='${tidOutput}' AND authorid=1 AND first=0 AND message LIKE '%Admin quote reply to user thread.%';"`).toString().trim();

--- a/tools/test_forum_mobile.js
+++ b/tools/test_forum_mobile.js
@@ -92,6 +92,28 @@ const { execSync } = require('child_process');
             }
             assert.fail(`${message}. Found: ${dbScalar(sql)}`);
         };
+        const sendPrivateMessage = async (senderPage, recipient, message) => {
+            await senderPage.goto('http://127.0.0.1:8080/home.php?mod=spacecp&ac=pm');
+            await senderPage.waitForLoadState('networkidle');
+            const pmForm = senderPage.locator('form#pmform:visible');
+            assert.strictEqual(await pmForm.count(), 1, 'Assertion Error: Mobile PM compose form did not render.');
+            const recipientInput = pmForm.locator('input[name="username"]');
+            const messageInput = pmForm.locator('textarea[name="message"]');
+            const submitButton = pmForm.locator('#pmsubmit_btn');
+            assert.strictEqual(await recipientInput.count(), 1, 'Assertion Error: Mobile PM recipient field did not render.');
+            assert.strictEqual(await messageInput.count(), 1, 'Assertion Error: Mobile PM message field did not render.');
+            assert.strictEqual(await submitButton.count(), 1, 'Assertion Error: Mobile PM submit button did not render.');
+            await recipientInput.fill(recipient);
+            await messageInput.fill(message);
+            const responsePromise = senderPage.waitForResponse(response =>
+                response.request().method() === 'POST' &&
+                response.url().includes('home.php?mod=spacecp&ac=pm&op=send')
+            );
+            await submitButton.click();
+            const response = await responsePromise;
+            const responseText = await response.text();
+            assert.ok(response.ok(), `Assertion Error: Mobile PM send request failed: status=${response.status()}; body=${responseText.slice(0, 2000)}`);
+        };
         const subject = `Mobile thread ${suffix}`;
         const message = `Mobile thread body ${suffix}.`;
         const reply = `Mobile reply ${suffix}.`;
@@ -242,12 +264,6 @@ const { execSync } = require('child_process');
         }
         assert.strictEqual(mobileAvatarStatus, '1', 'Assertion Error: Mobile user avatarstatus in database was not 1.');
 
-        console.log('Testing mobile PM center page...');
-        await page.goto('http://127.0.0.1:8080/home.php?mod=space&do=pm');
-        await page.waitForLoadState('networkidle');
-        assert.ok((await page.textContent('body')).length > 100, 'Assertion Error: Mobile PM center did not load content.');
-        await page.screenshot({ path: 'screenshot_mobile_07_pm.png' });
-
         console.log('Testing mobile viewthread thread tag rendering...');
         await page.goto(`http://127.0.0.1:8080/forum.php?mod=viewthread&tid=${tid}`);
         await page.waitForLoadState('networkidle');
@@ -284,6 +300,13 @@ const { execSync } = require('child_process');
             0,
             'Assertion Error: Mobile admin login did not establish an authenticated session.'
         );
+        const adminPmToMobileUser = 'Admin PM for mobile inbox.';
+        await sendPrivateMessage(adminMobilePage, username, adminPmToMobileUser);
+        assert.strictEqual(
+            dbScalar(`SELECT COUNT(*) FROM pre_common_pm_message p INNER JOIN pre_common_pm_member m ON m.plid=p.plid WHERE m.uid='${uid}' AND p.authorid='1' AND p.message='${adminPmToMobileUser}'`),
+            '1',
+            'Assertion Error: Admin PM was not delivered to the mobile user inbox.'
+        );
         await adminMobilePage.goto(`http://127.0.0.1:8080/forum.php?mod=post&action=reply&fid=2&tid=${tid}&reppost=${firstMobilePid}`);
         await adminMobilePage.waitForLoadState('networkidle');
         const adminReply = 'Admin mobile quote reply to user thread.';
@@ -313,6 +336,13 @@ const { execSync } = require('child_process');
             `Assertion Error: Mobile quote reply was not stored. Response: ${adminReplyResponseText.slice(0, 2000)}`
         );
         await adminMobileContext.close();
+
+        console.log('Testing mobile PM center page...');
+        await page.goto('http://127.0.0.1:8080/home.php?mod=space&do=pm');
+        await page.waitForLoadState('networkidle');
+        const mobilePmBody = await page.textContent('body');
+        assert.ok(mobilePmBody.includes(adminPmToMobileUser), 'Assertion Error: Mobile PM center did not display the delivered admin message.');
+        await page.screenshot({ path: 'screenshot_mobile_07_pm.png' });
 
         await page.goto('http://127.0.0.1:8080/home.php?mod=space&do=notice');
         await page.waitForLoadState('networkidle');


### PR DESCRIPTION
### Motivation

- Resolve incorrect group PM lookup/merge logic and avoid errors when group PM records are absent. 
- Change default personal thread view to show the user's own threads by default. 
- Prevent duplicate search UI/rendering by conditionally showing the search form or results. 
- Ensure CI seeding/config cache is updated so Playwright tests run against expected Discuz settings in GitHub Actions. 

### Description

- Adjusted group PM handling in `source/app/home/child/space/pm.php` to fetch the current user’s `gpm` entry first, only fetch the group record when appropriate, merge data reliably, guard status checks with existence checks, and decrement the `numbers` counter consistently. 
- Changed the default fallback for `$_GET['view']` in `source/app/home/child/space/thread.php` from `'we'` to `'me'` so personal threads are shown by default. 
- Updated `template/default/search/forum.htm` to conditionally render the search form when `empty($searchid)` and render the thread list only when `$searchid` is present, preventing simultaneous duplicate render. 
- Modified CI workflow `.github/workflows/playwright.yml` to seed the database setting `pre_common_setting.homestatus=1` and refresh Discuz caches by running `updatecache("setting")` after importing data so the test environment matches expected runtime configuration. 

### Testing

- Run Playwright test suite via CI which executes `node tools/test_forum.js`, `node tools/test_forum_mobile.js`, `node tools/test_search.js`, `node tools/test_tags.js`, and `node tools/test_admin.js`. All Playwright tests completed successfully in the workflow run. 
- CI also started a PHP built-in server and performed the PHP server error check step which reported no unexpected 4xx/5xx errors. 
- Test artifacts and screenshots were uploaded by the workflow after the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63069bdcb88331a4ca2175a38c90be)